### PR TITLE
Add impersonate, event timesheets, tags, and duplicate merge

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -24,6 +24,7 @@ import formCollection from './listeners/form-collection'
 import formErrors from './listeners/form-errors'
 import formTarget from './listeners/form-target'
 import imagePreviews from './listeners/image-previews'
+import impersonate from './listeners/impersonate'
 import like from './listeners/like'
 import loadMore from './listeners/load-more'
 import login from './listeners/login'
@@ -50,6 +51,7 @@ class App {
             formCollection,
             formErrors,
             formTarget,
+            impersonate,
             like,
             loadMore,
             login,

--- a/assets/js/listeners/impersonate.js
+++ b/assets/js/listeners/impersonate.js
@@ -1,0 +1,29 @@
+import Swal from 'sweetalert2'
+
+export default (di, container) => {
+    container.querySelectorAll('.js-impersonate').forEach((el) => {
+        el.addEventListener('click', async (e) => {
+            e.preventDefault()
+            const result = await Swal.fire({
+                title: 'Impersonation',
+                input: 'text',
+                inputLabel: 'Username',
+                inputPlaceholder: 'Enter the username',
+                showCancelButton: true,
+                cancelButtonText: 'Annuler',
+                heightAuto: false,
+                inputValidator: (value) => {
+                    if (!value) {
+                        return 'Please enter a username'
+                    }
+                },
+            })
+
+            if (result.isConfirmed) {
+                const url = new URL(window.location.href)
+                url.searchParams.set('_switch_user', result.value)
+                window.location.href = url.toString()
+            }
+        })
+    })
+}

--- a/templates/fragments/header.html.twig
+++ b/templates/fragments/header.html.twig
@@ -54,6 +54,7 @@
                             <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow" data-bs-theme="light">
                                 <a class="dropdown-item" href="{{ path('admin') }}">Administration</a>
                                 <a class="dropdown-item" href="{{ path('app_administration_info_index') }}">Réseaux Sociaux</a>
+                                <a class="dropdown-item js-impersonate" href="#">Impersonation</a>
                             </div>
                         </li>
                 </ul>


### PR DESCRIPTION
## Summary
- Add admin impersonation via SweetAlert2 prompt in the admin dropdown, redirecting with `_switch_user` parameter
- Introduce `EventTimesheet` entity for managing multiple event timesheets with a Preact-based scheduler UI
- Add event tag autocomplete with Elasticsearch-backed API resource
- Add `EventsMergeDuplicatesCommand` for deduplicating events
- Add `EventIndexableChecker` and `EventUrlCheckSubscriber` for better event validation
- Comprehensive tests for new Firewall rules, Cleaner, Entity logic, and Elasticsearch indexability

## Test plan
- [ ] Verify impersonation: click "Impersonation" in admin dropdown, enter a username, confirm redirect with `_switch_user`
- [ ] Verify event timesheet CRUD works in the event form
- [ ] Verify tag autocomplete works on event pages
- [ ] Run `vendor/bin/phpunit` and `vendor/bin/phpstan analyse`
- [ ] Run `npm run build` to verify frontend compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)