### PR TITLE
Add user feedback system with email notification

### DIFF
--- a/.env
+++ b/.env
@@ -70,6 +70,10 @@ SENTRY_DSN=
 MAILER_DSN=null://null
 ###< symfony/mailer ###
 
+###> Feedback ###
+FEEDBACK_RECIPIENT_EMAIL=contact@by-night.fr
+###< Feedback ###
+
 ###> php-amqplib/rabbitmq-bundle ###
 RABBITMQ_URL=amqp://guest:guest@localhost:5672?lazy=1
 ###< php-amqplib/rabbitmq-bundle ###

--- a/assets/js/pages/espace_perso_list.js
+++ b/assets/js/pages/espace_perso_list.js
@@ -33,4 +33,57 @@ $(document).ready(function () {
             self.attr('disabled', false)
         })
     })
+
+    // Feedback form
+    const feedbackForm = $('#feedback-form')
+    const feedbackModal = $('#feedbackModal')
+    const feedbackMessage = $('#feedback-message')
+    const feedbackError = $('#feedback-error')
+    const submitBtn = feedbackForm.closest('.modal-content').find('button[type="submit"]')
+
+    feedbackForm.on('submit', function (e) {
+        e.preventDefault()
+
+        const message = feedbackMessage.val().trim()
+        if (message.length < 10) {
+            feedbackMessage.addClass('is-invalid')
+            feedbackError.text('Votre message doit faire au moins 10 caractères')
+            return
+        }
+
+        feedbackMessage.removeClass('is-invalid')
+        submitBtn.attr('disabled', true)
+
+        $.ajax({
+            url: feedbackForm.data('action'),
+            type: 'POST',
+            contentType: 'application/json',
+            data: JSON.stringify({ message: message }),
+        })
+            .done(function (response) {
+                window.App.get('toastManager').createToast('success', response.message)
+                feedbackModal.modal('hide')
+                $('#feedback-banner').alert('close')
+            })
+            .fail(function (xhr) {
+                let errorMessage = 'Une erreur est survenue'
+                if (xhr.responseJSON && xhr.responseJSON.detail) {
+                    errorMessage = xhr.responseJSON.detail
+                } else if (xhr.responseJSON && xhr.responseJSON.violations) {
+                    errorMessage = xhr.responseJSON.violations.map((v) => v.message).join(', ')
+                }
+                feedbackMessage.addClass('is-invalid')
+                feedbackError.text(errorMessage)
+            })
+            .always(function () {
+                submitBtn.attr('disabled', false)
+            })
+    })
+
+    // Reset form when modal is closed
+    feedbackModal.on('hidden.bs.modal', function () {
+        feedbackForm[0].reset()
+        feedbackMessage.removeClass('is-invalid')
+        feedbackError.text('')
+    })
 })

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,6 +7,7 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    feedback_recipient_email: '%env(FEEDBACK_RECIPIENT_EMAIL)%'
     facebook_id_page: '205292952998805'
     google_map_key: '%env(GOOGLE_MAP_KEY_WEB)%'
     google_map_id: '%env(GOOGLE_MAP_ID)%'

--- a/src/Api/ApiResource/Feedback.php
+++ b/src/Api/ApiResource/Feedback.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Api\ApiResource;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Post;
+use App\Api\Model\FeedbackInput;
+use App\Api\Model\FeedbackOutput;
+use App\Api\Processor\FeedbackProcessor;
+
+#[ApiResource(operations: [
+    new Post(
+        uriTemplate: '/feedback',
+        security: "is_granted('ROLE_USER')",
+        securityMessage: 'Vous devez être connecté pour envoyer un feedback.',
+        input: FeedbackInput::class,
+        output: FeedbackOutput::class,
+        name: 'api_feedback',
+        processor: FeedbackProcessor::class,
+    ),
+])]
+final class Feedback
+{
+}

--- a/src/Api/Model/FeedbackInput.php
+++ b/src/Api/Model/FeedbackInput.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Api\Model;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final readonly class FeedbackInput
+{
+    public function __construct(
+        #[Assert\NotBlank(message: 'Veuillez entrer votre message')]
+        #[Assert\Length(min: 10, minMessage: 'Votre message doit faire au moins {{ limit }} caractères')]
+        public string $message = '',
+    ) {
+    }
+}

--- a/src/Api/Model/FeedbackOutput.php
+++ b/src/Api/Model/FeedbackOutput.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Api\Model;
+
+final readonly class FeedbackOutput
+{
+    public function __construct(
+        public bool $success,
+        public ?string $message = null,
+    ) {
+    }
+}

--- a/src/Api/Processor/FeedbackProcessor.php
+++ b/src/Api/Processor/FeedbackProcessor.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Api\Processor;
+
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\ProcessorInterface;
+use App\Api\Model\FeedbackInput;
+use App\Api\Model\FeedbackOutput;
+use App\Entity\User;
+use App\Manager\MailerManager;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * @implements ProcessorInterface<FeedbackInput, FeedbackOutput>
+ */
+final readonly class FeedbackProcessor implements ProcessorInterface
+{
+    public function __construct(
+        private MailerManager $mailerManager,
+        private Security $security,
+        #[Autowire('%feedback_recipient_email%')]
+        private string $feedbackRecipientEmail,
+    ) {
+    }
+
+    public function process(mixed $data, Operation $operation, array $uriVariables = [], array $context = []): FeedbackOutput
+    {
+        /** @var User $user */
+        $user = $this->security->getUser();
+
+        $this->mailerManager->sendFeedbackEmail($user, $data->message, $this->feedbackRecipientEmail);
+
+        return new FeedbackOutput(
+            success: true,
+            message: 'Merci pour votre retour !',
+        );
+    }
+}

--- a/src/Manager/MailerManager.php
+++ b/src/Manager/MailerManager.php
@@ -48,6 +48,20 @@ final readonly class MailerManager
         $this->sendMail($email);
     }
 
+    public function sendFeedbackEmail(User $user, string $message, string $recipientEmail): void
+    {
+        $email = new TemplatedEmail()
+            ->to($recipientEmail)
+            ->subject('Feedback utilisateur - By Night')
+            ->htmlTemplate('email/feedback.html.twig')
+            ->context([
+                'user' => $user,
+                'message' => $message,
+            ]);
+
+        $this->sendMail($email);
+    }
+
     private function sendMail(Email $email): void
     {
         $email->from(new Address('support@by-night.fr', 'By Night'));

--- a/templates/email/feedback.html.twig
+++ b/templates/email/feedback.html.twig
@@ -1,0 +1,9 @@
+<h1>Nouveau feedback utilisateur</h1>
+
+<p>
+    <strong>De :</strong> {{ user.username }} ({{ user.email }})<br>
+    <strong>Date :</strong> {{ 'now'|date('d/m/Y H:i') }}
+</p>
+
+<h2>Message :</h2>
+<p>{{ message|nl2br }}</p>

--- a/templates/espace-perso/index.html.twig
+++ b/templates/espace-perso/index.html.twig
@@ -11,6 +11,16 @@
             </div>
         </div>
     {% endif %}
+    <div class="alert alert-dismissible fade show alert-info" id="feedback-banner">
+        <div class="{{ block('container_class') }}">
+            <twig:Icon name="lucide:message-circle" />
+            <strong>Nouveau !</strong> Nous avons amélioré la gestion de vos événements.
+            <a href="#" class="alert-link" data-bs-toggle="modal" data-bs-target="#feedbackModal">
+                Donnez-nous votre avis
+            </a>
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Fermer"></button>
+        </div>
+    </div>
 {% endblock %}
 
 {% block title_after %}
@@ -105,3 +115,36 @@
 {% block js -%}
     {{ encore_entry_script_tags('espace_perso_list') }}
 {%- endblock %}
+
+{% block modals %}
+    <div class="modal fade" id="feedbackModal" tabindex="-1" aria-labelledby="feedbackModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h3 class="modal-title" id="feedbackModalLabel">Donnez-nous votre avis</h3>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="text-muted mb-3">
+                        Nous avons récemment mis à jour le système de gestion de vos événements.
+                        Votre avis nous aide à améliorer l'expérience !
+                    </p>
+                    <form id="feedback-form" data-action="{{ path('api_feedback') }}">
+                        <div class="mb-3">
+                            <label for="feedback-message" class="form-label">Votre message</label>
+                            <textarea class="form-control" id="feedback-message" rows="5" placeholder="Partagez votre avis sur le nouveau système..." required minlength="10"></textarea>
+                            <div class="invalid-feedback" id="feedback-error"></div>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Fermer</button>
+                    <button type="submit" form="feedback-form" class="btn btn-primary">
+                        <twig:Icon name="lucide:send" />
+                        Envoyer
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/tests/Api/FeedbackTest.php
+++ b/tests/Api/FeedbackTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Tests\Api;
+
+use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
+use ApiPlatform\Symfony\Bundle\Test\Client;
+use App\Factory\UserFactory;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Zenstruck\Foundry\Persistence\Proxy;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+final class FeedbackTest extends ApiTestCase
+{
+    use Factories;
+    use ResetDatabase;
+
+    protected static ?bool $alwaysBootKernel = true;
+
+    public function testFeedbackRequiresAuthentication(): void
+    {
+        self::createClient()->request('POST', '/api/feedback', [
+            'json' => ['message' => 'This is my feedback message'],
+        ]);
+
+        self::assertResponseRedirects('/login');
+    }
+
+    public function testFeedbackWithValidMessage(): void
+    {
+        $user = UserFactory::createOne();
+
+        $this->createAuthenticatedClient($user)->request('POST', '/api/feedback', [
+            'headers' => ['Accept' => 'application/json'],
+            'json' => ['message' => 'This is my feedback message about the new system.'],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('content-type', 'application/json; charset=utf-8');
+        self::assertJsonContains([
+            'success' => true,
+            'message' => 'Merci pour votre retour !',
+        ]);
+    }
+
+    public function testFeedbackSendsEmail(): void
+    {
+        $user = UserFactory::createOne([
+            'username' => 'testuser',
+            'email' => 'testuser@example.com',
+        ]);
+
+        $this->createAuthenticatedClient($user)->request('POST', '/api/feedback', [
+            'headers' => ['Accept' => 'application/json'],
+            'json' => ['message' => 'This is my feedback message for email test.'],
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertEmailCount(1);
+
+        $email = self::getMailerMessage();
+        self::assertEmailHeaderSame($email, 'Subject', 'Feedback utilisateur - By Night');
+        self::assertEmailHtmlBodyContains($email, 'testuser');
+        self::assertEmailHtmlBodyContains($email, 'testuser@example.com');
+        self::assertEmailHtmlBodyContains($email, 'This is my feedback message for email test.');
+    }
+
+    public function testFeedbackWithEmptyMessageFails(): void
+    {
+        $user = UserFactory::createOne();
+
+        $this->createAuthenticatedClient($user)->request('POST', '/api/feedback', [
+            'headers' => ['Accept' => 'application/json'],
+            'json' => ['message' => ''],
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    public function testFeedbackWithTooShortMessageFails(): void
+    {
+        $user = UserFactory::createOne();
+
+        $this->createAuthenticatedClient($user)->request('POST', '/api/feedback', [
+            'headers' => ['Accept' => 'application/json'],
+            'json' => ['message' => 'Short'],
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+        self::assertJsonContains([
+            'violations' => [
+                [
+                    'propertyPath' => 'message',
+                ],
+            ],
+        ]);
+    }
+
+    public function testFeedbackWithMissingMessageFails(): void
+    {
+        $user = UserFactory::createOne();
+
+        $this->createAuthenticatedClient($user)->request('POST', '/api/feedback', [
+            'headers' => ['Accept' => 'application/json'],
+            'json' => [],
+        ]);
+
+        self::assertResponseStatusCodeSame(422);
+    }
+
+    private function createAuthenticatedClient(UserInterface|Proxy $user): Client
+    {
+        $user = $user instanceof Proxy ? $user->_real() : $user;
+        $client = self::createClient();
+        $client->loginUser($user);
+
+        return $client;
+    }
+}


### PR DESCRIPTION
## Summary
- Add API Platform endpoint `POST /api/feedback` for authenticated users to submit feedback
- Display feedback banner and modal on the "Mes événements" page
- Send email notification to configurable recipient (via `FEEDBACK_RECIPIENT_EMAIL` env var)
- Include client-side and server-side validation (min 10 characters)

## Test plan
- [x] Unit tests for all API scenarios (auth, validation, email sending)
- [ ] Manual test: login, navigate to /espace-perso/mes-soirees, submit feedback via modal

🤖 Generated with [Claude Code](https://claude.ai/code)