### PR TITLE
Use EasyAdmin pretty URLs with AdminDashboard and AdminRoute attributes

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -35,13 +35,6 @@ app.comments:
     prefix: /commentaire
     type: attribute
 
-app.admin:
-    resource:
-        path: ../src/Controller/Admin
-        namespace: App\Controller\Admin
-    prefix: /_administration
-    type: attribute
-
 app.private:
     resource:
         path: ../src/Controller/Fragments

--- a/config/routes/easyadmin.yaml
+++ b/config/routes/easyadmin.yaml
@@ -1,0 +1,4 @@
+easyadmin:
+    resource: .
+    type: easyadmin.routes
+    prefix: /_administration

--- a/src/Controller/Admin/AdminZoneCrudController.php
+++ b/src/Controller/Admin/AdminZoneCrudController.php
@@ -11,6 +11,7 @@
 namespace App\Controller\Admin;
 
 use App\Entity\AdminZone;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
@@ -21,6 +22,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 use RuntimeException;
 
+#[AdminRoute(routePath: '/admin-zone', routeName: 'admin_zone')]
 class AdminZoneCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/AdminZoneCrudController.php
+++ b/src/Controller/Admin/AdminZoneCrudController.php
@@ -22,7 +22,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 use RuntimeException;
 
-#[AdminRoute(routePath: '/admin-zone', routeName: 'admin_zone')]
+#[AdminRoute(path: '/admin-zone', name: 'admin_zone')]
 class AdminZoneCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/AppOAuthCrudController.php
+++ b/src/Controller/Admin/AppOAuthCrudController.php
@@ -11,9 +11,11 @@
 namespace App\Controller\Admin;
 
 use App\Entity\AppOAuth;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use Override;
 
+#[AdminRoute(routePath: '/app-oauth', routeName: 'app_oauth')]
 final class AppOAuthCrudController extends OAuthCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/AppOAuthCrudController.php
+++ b/src/Controller/Admin/AppOAuthCrudController.php
@@ -15,7 +15,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use Override;
 
-#[AdminRoute(routePath: '/app-oauth', routeName: 'app_oauth')]
+#[AdminRoute(path: '/app-oauth', name: 'app_oauth')]
 final class AppOAuthCrudController extends OAuthCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/CityCrudController.php
+++ b/src/Controller/Admin/CityCrudController.php
@@ -15,7 +15,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use Override;
 
-#[AdminRoute(routePath: '/city', routeName: 'city')]
+#[AdminRoute(path: '/city', name: 'city')]
 final class CityCrudController extends AdminZoneCrudController
 {
     #[Override]

--- a/src/Controller/Admin/CityCrudController.php
+++ b/src/Controller/Admin/CityCrudController.php
@@ -11,9 +11,11 @@
 namespace App\Controller\Admin;
 
 use App\Entity\City;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use Override;
 
+#[AdminRoute(routePath: '/city', routeName: 'city')]
 final class CityCrudController extends AdminZoneCrudController
 {
     #[Override]

--- a/src/Controller/Admin/CommentCrudController.php
+++ b/src/Controller/Admin/CommentCrudController.php
@@ -21,7 +21,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use Override;
 
-#[AdminRoute(routePath: '/comment', routeName: 'comment')]
+#[AdminRoute(path: '/comment', name: 'comment')]
 final class CommentCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/CommentCrudController.php
+++ b/src/Controller/Admin/CommentCrudController.php
@@ -11,6 +11,7 @@
 namespace App\Controller\Admin;
 
 use App\Entity\Comment;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
@@ -20,6 +21,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use Override;
 
+#[AdminRoute(routePath: '/comment', routeName: 'comment')]
 final class CommentCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/CountryCrudController.php
+++ b/src/Controller/Admin/CountryCrudController.php
@@ -17,7 +17,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 
-#[AdminRoute(routePath: '/country', routeName: 'country')]
+#[AdminRoute(path: '/country', name: 'country')]
 final class CountryCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/CountryCrudController.php
+++ b/src/Controller/Admin/CountryCrudController.php
@@ -11,11 +11,13 @@
 namespace App\Controller\Admin;
 
 use App\Entity\Country;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 
+#[AdminRoute(routePath: '/country', routeName: 'country')]
 final class CountryCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -21,6 +21,7 @@ use App\Entity\User;
 use App\Entity\UserEvent;
 use App\Entity\UserOAuth;
 use App\Picture\UserProfilePicture;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -31,16 +32,15 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Override;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\User\UserInterface;
 
+#[AdminDashboard(routePath: '/', routeName: 'admin')]
 final class DashboardController extends AbstractDashboardController
 {
     public function __construct(private readonly UserProfilePicture $userProfilePicture, private readonly AdminUrlGenerator $adminUrlGenerator)
     {
     }
 
-    #[Route(path: '/', name: 'admin', methods: ['GET', 'POST'])]
     #[Override]
     public function index(): Response
     {

--- a/src/Controller/Admin/EventCrudController.php
+++ b/src/Controller/Admin/EventCrudController.php
@@ -32,7 +32,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 use Override;
 
-#[AdminRoute(routePath: '/event', routeName: 'event')]
+#[AdminRoute(path: '/event', name: 'event')]
 final class EventCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/EventCrudController.php
+++ b/src/Controller/Admin/EventCrudController.php
@@ -13,6 +13,7 @@ namespace App\Controller\Admin;
 use App\Admin\Filter\UserWithEventFilter;
 use App\Entity\Event;
 use App\Form\Type\EventTimesheetEntityType;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
@@ -31,6 +32,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use EasyCorp\Bundle\EasyAdminBundle\Filter\EntityFilter;
 use Override;
 
+#[AdminRoute(routePath: '/event', routeName: 'event')]
 final class EventCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/EventTimesheetCrudController.php
+++ b/src/Controller/Admin/EventTimesheetCrudController.php
@@ -20,7 +20,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 
-#[AdminRoute(routePath: '/event-timesheet', routeName: 'event_timesheet')]
+#[AdminRoute(path: '/event-timesheet', name: 'event_timesheet')]
 final class EventTimesheetCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/EventTimesheetCrudController.php
+++ b/src/Controller/Admin/EventTimesheetCrudController.php
@@ -11,6 +11,7 @@
 namespace App\Controller\Admin;
 
 use App\Entity\EventTimesheet;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
@@ -19,6 +20,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 
+#[AdminRoute(routePath: '/event-timesheet', routeName: 'event_timesheet')]
 final class EventTimesheetCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/ParserDataCrudController.php
+++ b/src/Controller/Admin/ParserDataCrudController.php
@@ -23,7 +23,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 use RuntimeException;
 
-#[AdminRoute(routePath: '/parser-data', routeName: 'parser_data')]
+#[AdminRoute(path: '/parser-data', name: 'parser_data')]
 final class ParserDataCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/ParserDataCrudController.php
+++ b/src/Controller/Admin/ParserDataCrudController.php
@@ -11,6 +11,7 @@
 namespace App\Controller\Admin;
 
 use App\Entity\ParserData;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -22,6 +23,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 use RuntimeException;
 
+#[AdminRoute(routePath: '/parser-data', routeName: 'parser_data')]
 final class ParserDataCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/ParserHistoryCrudController.php
+++ b/src/Controller/Admin/ParserHistoryCrudController.php
@@ -23,7 +23,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 use RuntimeException;
 
-#[AdminRoute(routePath: '/parser-history', routeName: 'parser_history')]
+#[AdminRoute(path: '/parser-history', name: 'parser_history')]
 final class ParserHistoryCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/ParserHistoryCrudController.php
+++ b/src/Controller/Admin/ParserHistoryCrudController.php
@@ -11,6 +11,7 @@
 namespace App\Controller\Admin;
 
 use App\Entity\ParserHistory;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -22,6 +23,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 use RuntimeException;
 
+#[AdminRoute(routePath: '/parser-history', routeName: 'parser_history')]
 final class ParserHistoryCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/PlaceCrudController.php
+++ b/src/Controller/Admin/PlaceCrudController.php
@@ -24,7 +24,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 
-#[AdminRoute(routePath: '/place', routeName: 'place')]
+#[AdminRoute(path: '/place', name: 'place')]
 final class PlaceCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/PlaceCrudController.php
+++ b/src/Controller/Admin/PlaceCrudController.php
@@ -11,6 +11,7 @@
 namespace App\Controller\Admin;
 
 use App\Entity\Place;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
@@ -23,6 +24,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\NumberField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 
+#[AdminRoute(routePath: '/place', routeName: 'place')]
 final class PlaceCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -11,6 +11,7 @@
 namespace App\Controller\Admin;
 
 use App\Entity\User;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -26,6 +27,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 
+#[AdminRoute(routePath: '/user', routeName: 'user')]
 final class UserCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -27,7 +27,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\TextareaField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Override;
 
-#[AdminRoute(routePath: '/user', routeName: 'user')]
+#[AdminRoute(path: '/user', name: 'user')]
 final class UserCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/UserEventCrudController.php
+++ b/src/Controller/Admin/UserEventCrudController.php
@@ -20,7 +20,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use Override;
 
-#[AdminRoute(routePath: '/user-event', routeName: 'user_event')]
+#[AdminRoute(path: '/user-event', name: 'user_event')]
 final class UserEventCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/UserEventCrudController.php
+++ b/src/Controller/Admin/UserEventCrudController.php
@@ -11,6 +11,7 @@
 namespace App\Controller\Admin;
 
 use App\Entity\UserEvent;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
@@ -19,6 +20,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use Override;
 
+#[AdminRoute(routePath: '/user-event', routeName: 'user_event')]
 final class UserEventCrudController extends AbstractCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/UserOAuthCrudController.php
+++ b/src/Controller/Admin/UserOAuthCrudController.php
@@ -11,11 +11,13 @@
 namespace App\Controller\Admin;
 
 use App\Entity\UserOAuth;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use Override;
 
+#[AdminRoute(routePath: '/user-oauth', routeName: 'user_oauth')]
 final class UserOAuthCrudController extends OAuthCrudController
 {
     public static function getEntityFqcn(): string

--- a/src/Controller/Admin/UserOAuthCrudController.php
+++ b/src/Controller/Admin/UserOAuthCrudController.php
@@ -17,7 +17,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use Override;
 
-#[AdminRoute(routePath: '/user-oauth', routeName: 'user_oauth')]
+#[AdminRoute(path: '/user-oauth', name: 'user_oauth')]
 final class UserOAuthCrudController extends OAuthCrudController
 {
     public static function getEntityFqcn(): string


### PR DESCRIPTION
## Summary
- Add `#[AdminDashboard]` attribute to DashboardController for automatic route generation
- Add `#[AdminRoute]` attributes to all 14 CRUD controllers with semantic route names
- Create `config/routes/easyadmin.yaml` with the EasyAdmin route loader and `/_administration` prefix
- Remove manual admin route configuration from `routes.yaml`

This enables EasyAdmin's pretty URLs feature (e.g., `/_administration/event/123` instead of query string parameters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)