### PR TITLE
Add dropzone upload for event images with 16:9 ratio hint

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -19,6 +19,7 @@ import autocomplete from './global-listeners/autocomplete'
 import scrollToTop from './global-listeners/scroll-to-top'
 
 // Listeners
+import dropzone from './listeners/dropzone'
 import emailVerify from './listeners/email-verify'
 import formCollection from './listeners/form-collection'
 import formErrors from './listeners/form-errors'
@@ -47,6 +48,7 @@ class App {
         this.#listeners = [autocomplete, imagePreviews, lazyload, scrollToTop]
 
         this.#pageListeners = [
+            dropzone,
             emailVerify,
             formCollection,
             formErrors,

--- a/assets/js/listeners/dropzone.js
+++ b/assets/js/listeners/dropzone.js
@@ -1,0 +1,116 @@
+const DROPZONE_SELECTOR = '.dropzone'
+const FILE_INPUT_SELECTOR = 'input[type="file"]'
+const PREVIEW_SELECTOR = '.dropzone-preview'
+const PLACEHOLDER_SELECTOR = '.dropzone-placeholder'
+
+const handleDragOver = (e) => {
+    e.preventDefault()
+    e.stopPropagation()
+    e.currentTarget.classList.add('dropzone-dragover')
+}
+
+const handleDragLeave = (e) => {
+    e.preventDefault()
+    e.stopPropagation()
+    e.currentTarget.classList.remove('dropzone-dragover')
+}
+
+const handleDrop = (e) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    const dropzone = e.currentTarget
+    dropzone.classList.remove('dropzone-dragover')
+
+    const fileInput = dropzone.querySelector(FILE_INPUT_SELECTOR)
+    if (!fileInput || !e.dataTransfer.files.length) {
+        return
+    }
+
+    // Only handle single file
+    const file = e.dataTransfer.files[0]
+
+    // Validate file is an image
+    if (!file.type.startsWith('image/')) {
+        return
+    }
+
+    // Create a new DataTransfer to set files on the input
+    const dataTransfer = new DataTransfer()
+    dataTransfer.items.add(file)
+    fileInput.files = dataTransfer.files
+
+    // Trigger change event to update preview
+    fileInput.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
+const handleFileChange = (e) => {
+    const fileInput = e.target
+    const dropzone = fileInput.closest(DROPZONE_SELECTOR)
+    if (!dropzone) {
+        return
+    }
+
+    const preview = dropzone.querySelector(PREVIEW_SELECTOR)
+    const placeholder = dropzone.querySelector(PLACEHOLDER_SELECTOR)
+
+    if (!fileInput.files || !fileInput.files.length) {
+        // No file selected, show placeholder
+        if (preview) {
+            preview.innerHTML = ''
+            preview.classList.add('d-none')
+        }
+        if (placeholder) {
+            placeholder.classList.remove('d-none')
+        }
+        return
+    }
+
+    const file = fileInput.files[0]
+    if (!file.type.startsWith('image/')) {
+        return
+    }
+
+    // Create preview
+    const reader = new FileReader()
+    reader.onload = (event) => {
+        if (preview) {
+            preview.innerHTML = `<img src="${event.target.result}" alt="Preview" class="img-fluid rounded" />`
+            preview.classList.remove('d-none')
+        }
+        if (placeholder) {
+            placeholder.classList.add('d-none')
+        }
+    }
+    reader.readAsDataURL(file)
+}
+
+const handleClick = (e) => {
+    // Only trigger file input if clicking on the dropzone area itself, not on the file input or existing preview link
+    if (e.target.closest('a') || e.target.closest('input') || e.target.closest('button')) {
+        return
+    }
+
+    const dropzone = e.currentTarget
+    const fileInput = dropzone.querySelector(FILE_INPUT_SELECTOR)
+    if (fileInput) {
+        fileInput.click()
+    }
+}
+
+export default () => {
+    document.querySelectorAll(DROPZONE_SELECTOR).forEach((dropzone) => {
+        // Remove existing listeners by cloning (simple approach for re-init)
+        const fileInput = dropzone.querySelector(FILE_INPUT_SELECTOR)
+
+        // Add event listeners
+        dropzone.addEventListener('dragover', handleDragOver)
+        dropzone.addEventListener('dragleave', handleDragLeave)
+        dropzone.addEventListener('drop', handleDrop)
+        dropzone.addEventListener('click', handleClick)
+
+        if (fileInput) {
+            fileInput.addEventListener('change', handleFileChange)
+        }
+    })
+}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -16,6 +16,7 @@
 @import 'components/collections';
 @import 'components/comment';
 @import 'components/criteres';
+@import 'components/dropzone';
 @import 'components/event';
 @import 'components/event-scheduler';
 @import 'components/footer';

--- a/assets/scss/components/_dropzone.scss
+++ b/assets/scss/components/_dropzone.scss
@@ -1,0 +1,81 @@
+.dropzone {
+    border: 2px dashed var(--#{$prefix}border-color);
+    border-radius: $border-radius-lg;
+    padding: 1.5rem;
+    text-align: center;
+    cursor: pointer;
+    transition:
+        border-color 0.2s ease,
+        background-color 0.2s ease;
+    background-color: var(--#{$prefix}tertiary-bg);
+
+    &:hover,
+    &.dropzone-dragover {
+        border-color: $primary;
+        background-color: rgba($primary, 0.05);
+    }
+
+    &.dropzone-dragover {
+        border-style: solid;
+    }
+}
+
+.dropzone-placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--#{$prefix}secondary-color);
+
+    .dropzone-icon {
+        font-size: 2.5rem;
+        opacity: 0.5;
+    }
+
+    .dropzone-text {
+        font-weight: 500;
+    }
+
+    .dropzone-hint {
+        font-size: $font-size-sm;
+    }
+}
+
+.dropzone-preview {
+    img {
+        max-height: 200px;
+        object-fit: contain;
+    }
+}
+
+.dropzone-existing {
+    margin-bottom: 1rem;
+
+    img {
+        max-height: 200px;
+        object-fit: contain;
+    }
+}
+
+// Hide the default file input styling within dropzone
+.dropzone .custom-file {
+    margin-top: 1rem;
+
+    input[type='file'] {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+    }
+}
+
+// Delete checkbox styling within dropzone
+.dropzone .delete-image {
+    margin-top: 1rem;
+    text-align: left;
+}

--- a/src/Form/Type/EventType.php
+++ b/src/Form/Type/EventType.php
@@ -71,6 +71,7 @@ final class EventType extends AbstractType
                 'label' => 'Affiche / Flyer',
                 'required' => false,
                 'thumb_params' => ['h' => 200, 'w' => 400, 'thumb' => 1],
+                'help' => 'Pour un meilleur rendu, préférez une image au format 16:9 (ex: 1920x1080)',
             ])
             ->add('hours', TextType::class, [
                 'label' => 'Horaires affichés',

--- a/templates/form/fields.html.twig
+++ b/templates/form/fields.html.twig
@@ -12,21 +12,33 @@
 {% endblock %}
 
 {% block vich_image_widget %}
-    {% if download_uri is defined and download_uri %}
-        <a class="image-gallery" href="{{ download_uri }}">
-            {% if download_uri %}
-                {{ image(image_thumb_params) }}
-            {% endif %}
-        </a>
-    {% endif %}
+    <div class="dropzone">
+        {% if download_uri is defined and download_uri %}
+            <div class="dropzone-existing">
+                <a class="image-gallery" href="{{ download_uri }}">
+                    {{ image(image_thumb_params) }}
+                </a>
+            </div>
+        {% endif %}
 
-    {{ form_widget(form.file) }}
+        <div class="dropzone-preview {{ download_uri is defined and download_uri ? 'd-none' : '' }}"></div>
 
-    {% if form.delete is defined %}
-        <div class="delete-image mt-2">
-            {{ form_row(form.delete) }}
+        <div class="dropzone-placeholder {{ download_uri is defined and download_uri ? 'd-none' : '' }}">
+            <div class="dropzone-icon">
+                <twig:Icon name="lucide:image-up" />
+            </div>
+            <div class="dropzone-text">Glissez-déposez une image ou cliquez pour parcourir</div>
+            <div class="dropzone-hint text-muted">PNG, JPG ou GIF</div>
         </div>
-    {% endif %}
+
+        {{ form_widget(form.file) }}
+
+        {% if form.delete is defined %}
+            <div class="delete-image">
+                {{ form_row(form.delete) }}
+            </div>
+        {% endif %}
+    </div>
 {% endblock %}
 
 {# Images #}


### PR DESCRIPTION
## Summary
- Replace basic file input with drag-and-drop dropzone for event image upload
- Add visual preview for newly selected images
- Display help text recommending 16:9 aspect ratio (1920x1080)

## Changes
- New `dropzone.js` listener for drag/drop and click-to-browse functionality
- New `_dropzone.scss` styles with hover/drag-over states
- Updated `vich_image_widget` Twig block with dropzone UI
- Added help text to EventType form field

🤖 Generated with [Claude Code](https://claude.ai/code)