### PR TITLE
Add ESLint CI job and limit Docker builds to tags only

### DIFF
--- a/.github/workflows/build-and-deploy-release.yml
+++ b/.github/workflows/build-and-deploy-release.yml
@@ -1,10 +1,7 @@
 name: Build And Deploy Release
 
 on:
-    pull_request:
     push:
-        branches:
-            - 'refs/pull/*'
         tags:
             - v*
 
@@ -12,15 +9,8 @@ jobs:
     build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
-            - name: Get all latest versions
-              if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
-              run: |
-                  echo TAG_VERSION=latest >> $GITHUB_ENV
-                  echo APP_VERSION=latest >> $GITHUB_ENV
-                  echo APP_VERSIONS=latest >> $GITHUB_ENV
+            - uses: actions/checkout@v4
             - name: Get all stable versions
-              if: ${{ startsWith(github.ref, 'refs/tags/v') }}
               run: |
                   echo TAG_VERSION=stable >> $GITHUB_ENV
                   echo APP_VERSION=$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g" | sed -E "s/v?([0-9]+)\.([0-9]+)\.([0-9]+)(-[a-zA-Z]+(\.[0-9]+)?)?/\1.\2.\3\4/g") >> $GITHUB_ENV
@@ -36,7 +26,6 @@ jobs:
     upload-assets:
         needs: build
         runs-on: ubuntu-latest
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         container:
             image: guystlr/by-night
             env:
@@ -53,7 +42,6 @@ jobs:
     deploy:
         needs: build
         runs-on: ubuntu-latest
-        if: startsWith(github.ref, 'refs/tags/v')
         steps:
             - name: Deploy to production
               uses: appleboy/ssh-action@master

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,3 +30,24 @@ jobs:
               uses: laminas/laminas-continuous-integration-action@v1
               with:
                   job: ${{ matrix.job }}
+
+    lint:
+        name: Lint
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.4'
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '24'
+                  cache: 'yarn'
+            - name: Install PHP dependencies
+              run: composer install --no-interaction --no-progress --prefer-dist
+            - name: Install Node dependencies
+              run: yarn install --frozen-lockfile
+            - name: Run ESLint
+              run: yarn lint

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "build": "encore production",
         "prepare": "husky",
         "icon:svg": "svgr --icon --out-dir assets/js/icons --ext jsx --no-index --jsx-runtime classic-preact -- assets/icons",
+        "lint": "eslint assets/**/*.{js,jsx}",
         "test": "jest",
         "test:watch": "jest --watch",
         "test:coverage": "jest --coverage"


### PR DESCRIPTION
## Summary
- Add a new `lint` job to continuous-integration.yml that runs ESLint on PRs
- Lint job sets up PHP 8.4 and runs composer install to support symfony/ux dependencies
- Docker build workflow now only triggers on version tags, not on PRs
- Add `yarn lint` script to package.json

## Test plan
- [ ] Verify lint job runs on PR creation
- [ ] Verify Docker build no longer runs on PRs
- [ ] Verify Docker build still works on version tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)