### PR TITLE
Use Symfony UX Icons with Lucide in EasyAdmin

### DIFF
--- a/assets/icons/lucide/folder-open.svg
+++ b/assets/icons/lucide/folder-open.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m6 14l1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"/></svg>

--- a/assets/icons/lucide/history.svg
+++ b/assets/icons/lucide/history.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9a9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5m4-1v5l4 2"/></g></svg>

--- a/assets/icons/lucide/home.svg
+++ b/assets/icons/lucide/home.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/><path d="M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></g></svg>

--- a/assets/icons/lucide/message-square.svg
+++ b/assets/icons/lucide/message-square.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M22 17a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 21.286V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2z"/></svg>

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -24,6 +24,7 @@ use App\Picture\UserProfilePicture;
 use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminDashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Assets;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
@@ -79,25 +80,33 @@ final class DashboardController extends AbstractDashboardController
     }
 
     #[Override]
+    public function configureAssets(): Assets
+    {
+        return parent::configureAssets()
+            ->useCustomIconSet('lucide')
+        ;
+    }
+
+    #[Override]
     public function configureMenuItems(): iterable
     {
-        yield MenuItem::linkToUrl('Back to Home', 'fas fa-home', '../')->setLinkTarget('_blank')->setLinkRel('noreferrer');
+        yield MenuItem::linkToUrl('Back to Home', 'lucide:home', '../')->setLinkTarget('_blank')->setLinkRel('noreferrer');
 
-        yield MenuItem::section('Commnunity', 'fas fa-folder-open');
-        yield MenuItem::linkToCrud('Events', 'fas fa-calendar-alt', Event::class);
-        yield MenuItem::linkToCrud('Places', 'fas fa-map-marker-alt', Place::class);
-        yield MenuItem::linkToCrud('Comments', 'fas fa-comment', Comment::class);
-        yield MenuItem::linkToCrud('User Event', 'fas fa-calendar-alt', UserEvent::class);
+        yield MenuItem::section('Commnunity', 'lucide:folder-open');
+        yield MenuItem::linkToCrud('Events', 'lucide:calendar-days', Event::class);
+        yield MenuItem::linkToCrud('Places', 'lucide:map-pin', Place::class);
+        yield MenuItem::linkToCrud('Comments', 'lucide:message-square', Comment::class);
+        yield MenuItem::linkToCrud('User Event', 'lucide:heart', UserEvent::class);
 
-        yield MenuItem::section('Users', 'fas fa-folder-open');
-        yield MenuItem::linkToCrud('Users', 'fas fa-users', User::class);
-        yield MenuItem::linkToCrud('User socials', 'fas fa-bullhorn', UserOAuth::class);
+        yield MenuItem::section('Users', 'lucide:folder-open');
+        yield MenuItem::linkToCrud('Users', 'lucide:users', User::class);
+        yield MenuItem::linkToCrud('User socials', 'lucide:megaphone', UserOAuth::class);
 
-        yield MenuItem::section('Administration', 'fas fa-folder-open');
-        yield MenuItem::linkToCrud('Countries', 'fas fa-globe-europe', Country::class);
-        yield MenuItem::linkToCrud('Site socials', 'fas fa-bullhorn', AppOAuth::class);
-        yield MenuItem::linkToCrud('Explorations', 'far fa-eye', ParserData::class);
-        yield MenuItem::linkToCrud('Historique Maj', 'fas fa-history', ParserHistory::class);
+        yield MenuItem::section('Administration', 'lucide:folder-open');
+        yield MenuItem::linkToCrud('Countries', 'lucide:globe', Country::class);
+        yield MenuItem::linkToCrud('Site socials', 'lucide:megaphone', AppOAuth::class);
+        yield MenuItem::linkToCrud('Explorations', 'lucide:eye', ParserData::class);
+        yield MenuItem::linkToCrud('Historique Maj', 'lucide:history', ParserHistory::class);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Configure EasyAdmin to use Symfony UX Icons with Lucide icon set via `configureAssets()` method
- Replace FontAwesome icons with Lucide icons in the admin menu
- Add missing Lucide icons (home, folder-open, message-square, history)

## Test plan
- [ ] Verify admin dashboard loads without errors
- [ ] Check all menu icons render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)