### PR TITLE
Migrate event SEO from microdata to JSON-LD and improve structured data

### DIFF
--- a/src/SEO/BreadcrumbJsonLd.php
+++ b/src/SEO/BreadcrumbJsonLd.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\SEO;
+
+use WhiteOctober\BreadcrumbsBundle\Model\Breadcrumbs;
+
+final readonly class BreadcrumbJsonLd
+{
+    public function generateBreadcrumbJsonLd(Breadcrumbs $breadcrumbs): string
+    {
+        $items = [];
+        $position = 1;
+
+        foreach ($breadcrumbs as $breadcrumb) {
+            $item = [
+                '@type' => 'ListItem',
+                'position' => $position,
+                'name' => $breadcrumb['text'],
+            ];
+
+            if (!empty($breadcrumb['url'])) {
+                $item['item'] = $breadcrumb['url'];
+            }
+
+            $items[] = $item;
+            ++$position;
+        }
+
+        if ([] === $items) {
+            return '';
+        }
+
+        $schema = [
+            '@context' => 'https://schema.org',
+            '@type' => 'BreadcrumbList',
+            'itemListElement' => $items,
+        ];
+
+        return json_encode($schema, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT);
+    }
+}

--- a/src/SEO/EventJsonLd.php
+++ b/src/SEO/EventJsonLd.php
@@ -81,7 +81,7 @@ final readonly class EventJsonLd
 
         if ($event->getPlace()) {
             $location['url'] = $this->urlGenerator->generate('app_agenda_by_place', [
-                'slug' => $event->getPlace()->getSlug(),
+                'placeSlug' => $event->getPlace()->getSlug(),
                 'location' => $event->getLocationSlug(),
             ], UrlGeneratorInterface::ABSOLUTE_URL);
         }

--- a/src/SEO/EventJsonLd.php
+++ b/src/SEO/EventJsonLd.php
@@ -22,17 +22,30 @@ final readonly class EventJsonLd
     ) {
     }
 
-    public function generateEventSchema(Event $event): array
+    public function generateEventJsonLd(Event $event): string
+    {
+        $schema = $this->generateEventSchema($event);
+
+        return $this->toJson($schema);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function generateEventSchema(Event $event): array
     {
         $schema = [
             '@context' => 'https://schema.org',
             '@type' => 'Event',
             'name' => $event->getName(),
             'url' => $this->generateEventUrl($event),
-            'startDate' => $event->getStartDate()?->format('c'),
             'eventStatus' => $this->mapEventStatus($event->getStatus()),
             'eventAttendanceMode' => 'https://schema.org/OfflineEventAttendanceMode',
         ];
+
+        if ($event->getStartDate()) {
+            $schema['startDate'] = $event->getStartDate()->format('c');
+        }
 
         if ($event->getDescription()) {
             $schema['description'] = strip_tags($event->getDescription());
@@ -156,8 +169,11 @@ final readonly class EventJsonLd
         ], UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
-    public function toJson(array $schema): string
+    /**
+     * @param array<string, mixed> $schema
+     */
+    private function toJson(array $schema): string
     {
-        return json_encode($schema, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT);
+        return json_encode($schema, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT);
     }
 }

--- a/src/SEO/EventJsonLd.php
+++ b/src/SEO/EventJsonLd.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\SEO;
+
+use App\Entity\Event;
+use App\Picture\EventProfilePicture;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final readonly class EventJsonLd
+{
+    public function __construct(
+        private UrlGeneratorInterface $urlGenerator,
+        private EventProfilePicture $eventProfilePicture,
+    ) {
+    }
+
+    public function generateEventSchema(Event $event): array
+    {
+        $schema = [
+            '@context' => 'https://schema.org',
+            '@type' => 'Event',
+            'name' => $event->getName(),
+            'url' => $this->generateEventUrl($event),
+            'startDate' => $event->getStartDate()?->format('c'),
+            'eventStatus' => $this->mapEventStatus($event->getStatus()),
+            'eventAttendanceMode' => 'https://schema.org/OfflineEventAttendanceMode',
+        ];
+
+        if ($event->getDescription()) {
+            $schema['description'] = strip_tags($event->getDescription());
+        }
+
+        $endDate = $event->getEndDate() ?? $event->getStartDate();
+        if ($endDate) {
+            $schema['endDate'] = $endDate->format('c');
+        }
+
+        if ($event->hasImage()) {
+            $schema['image'] = $this->eventProfilePicture->getOriginalPicture($event);
+        }
+
+        $schema['location'] = $this->buildLocationSchema($event);
+
+        if ($event->getUser()) {
+            $schema['organizer'] = $this->buildOrganizerSchema($event);
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildLocationSchema(Event $event): array
+    {
+        $location = [
+            '@type' => 'Place',
+            'name' => $event->getPlaceName() ?? 'Lieu non communiqué',
+        ];
+
+        if ($event->getPlace()) {
+            $location['url'] = $this->urlGenerator->generate('app_agenda_by_place', [
+                'slug' => $event->getPlace()->getSlug(),
+                'location' => $event->getLocationSlug(),
+            ], UrlGeneratorInterface::ABSOLUTE_URL);
+        }
+
+        $address = ['@type' => 'PostalAddress'];
+        $hasAddress = false;
+
+        if ($event->getPlaceStreet()) {
+            $address['streetAddress'] = $event->getPlaceStreet();
+            $hasAddress = true;
+        }
+
+        if ($event->getPlaceCity()) {
+            $address['addressLocality'] = $event->getPlaceCity();
+            $hasAddress = true;
+        }
+
+        if ($event->getPlacePostalCode()) {
+            $address['postalCode'] = $event->getPlacePostalCode();
+            $hasAddress = true;
+        }
+
+        if ($event->getPlaceCountry()) {
+            $address['addressCountry'] = $event->getPlaceCountry()->getId();
+            $hasAddress = true;
+        }
+
+        if ($hasAddress) {
+            $location['address'] = $address;
+        }
+
+        if ($event->getLatitude() && $event->getLongitude()) {
+            $location['geo'] = [
+                '@type' => 'GeoCoordinates',
+                'latitude' => $event->getLatitude(),
+                'longitude' => $event->getLongitude(),
+            ];
+        }
+
+        return $location;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildOrganizerSchema(Event $event): array
+    {
+        $user = $event->getUser();
+
+        return [
+            '@type' => 'Person',
+            'name' => $user->getUsername(),
+            'url' => $this->urlGenerator->generate('app_user_index', [
+                'id' => $user->getId(),
+                'slug' => $user->getSlug(),
+            ], UrlGeneratorInterface::ABSOLUTE_URL),
+        ];
+    }
+
+    private function mapEventStatus(?string $status): string
+    {
+        if (!$status) {
+            return 'https://schema.org/EventScheduled';
+        }
+
+        $statusLower = mb_strtolower($status);
+
+        if (str_contains($statusLower, 'annul')) {
+            return 'https://schema.org/EventCancelled';
+        }
+
+        if (str_contains($statusLower, 'report')) {
+            return 'https://schema.org/EventPostponed';
+        }
+
+        return 'https://schema.org/EventScheduled';
+    }
+
+    private function generateEventUrl(Event $event): string
+    {
+        return $this->urlGenerator->generate('app_event_details', [
+            'slug' => $event->getSlug(),
+            'id' => $event->getId(),
+            'location' => $event->getLocationSlug(),
+        ], UrlGeneratorInterface::ABSOLUTE_URL);
+    }
+
+    public function toJson(array $schema): string
+    {
+        return json_encode($schema, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT);
+    }
+}

--- a/src/SEO/SiteJsonLd.php
+++ b/src/SEO/SiteJsonLd.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\SEO;
+
+use App\App\SocialManager;
+use Symfony\Component\Asset\Packages;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final readonly class SiteJsonLd
+{
+    public function __construct(
+        private UrlGeneratorInterface $urlGenerator,
+        private Packages $packages,
+        private SocialManager $socialManager,
+    ) {
+    }
+
+    public function generateSiteJsonLd(): string
+    {
+        $schema = $this->generateSiteSchema();
+
+        return json_encode($schema, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function generateSiteSchema(): array
+    {
+        $baseUrl = $this->urlGenerator->generate('app_index', [], UrlGeneratorInterface::ABSOLUTE_URL);
+        $searchUrl = $this->urlGenerator->generate('app_search_index', ['q' => '{search_term_string}'], UrlGeneratorInterface::ABSOLUTE_URL);
+        // URL decode the search URL to keep {search_term_string} as-is for schema.org
+        $searchUrl = urldecode($searchUrl);
+
+        $organization = [
+            '@type' => 'Organization',
+            '@id' => $baseUrl . '#organization',
+            'name' => 'By Night',
+            'url' => $baseUrl,
+            'logo' => $this->packages->getUrl('build/images/by-night.png', 'local'),
+        ];
+
+        $sameAs = $this->buildSameAsLinks();
+        if ([] !== $sameAs) {
+            $organization['sameAs'] = $sameAs;
+        }
+
+        return [
+            '@context' => 'https://schema.org',
+            '@graph' => [
+                [
+                    '@type' => 'WebSite',
+                    '@id' => $baseUrl . '#website',
+                    'url' => $baseUrl,
+                    'name' => 'By Night',
+                    'publisher' => [
+                        '@id' => $baseUrl . '#organization',
+                    ],
+                    'potentialAction' => [
+                        '@type' => 'SearchAction',
+                        'target' => $searchUrl,
+                        'query-input' => 'required name=search_term_string',
+                    ],
+                ],
+                $organization,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildSameAsLinks(): array
+    {
+        $sameAs = [];
+
+        $facebookId = $this->socialManager->getFacebookIdPage();
+        if ('' !== $facebookId) {
+            $sameAs[] = 'https://www.facebook.com/' . $facebookId;
+        }
+
+        $twitterId = $this->socialManager->getTwitterIdPage();
+        if ('' !== $twitterId) {
+            $sameAs[] = 'https://twitter.com/' . $twitterId;
+        }
+
+        return $sameAs;
+    }
+}

--- a/src/Twig/JsonLdExtension.php
+++ b/src/Twig/JsonLdExtension.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Twig;
+
+use App\Entity\Event;
+use App\SEO\EventJsonLd;
+use Twig\Attribute\AsTwigFunction;
+use WhiteOctober\BreadcrumbsBundle\Model\Breadcrumbs;
+
+final readonly class JsonLdExtension
+{
+    public function __construct(
+        private EventJsonLd $eventJsonLd,
+    ) {
+    }
+
+    #[AsTwigFunction(name: 'event_json_ld', isSafe: ['html'])]
+    public function eventJsonLd(Event $event): string
+    {
+        $schema = $this->eventJsonLd->generateEventSchema($event);
+        $json = $this->eventJsonLd->toJson($schema);
+
+        return \sprintf('<script type="application/ld+json">%s</script>', $json);
+    }
+
+    #[AsTwigFunction(name: 'breadcrumb_json_ld', isSafe: ['html'])]
+    public function breadcrumbJsonLd(Breadcrumbs $breadcrumbs): string
+    {
+        $items = [];
+        $position = 1;
+
+        foreach ($breadcrumbs as $breadcrumb) {
+            $item = [
+                '@type' => 'ListItem',
+                'position' => $position,
+                'name' => $breadcrumb['text'],
+            ];
+
+            if (!empty($breadcrumb['url'])) {
+                $item['item'] = $breadcrumb['url'];
+            }
+
+            $items[] = $item;
+            ++$position;
+        }
+
+        if ([] === $items) {
+            return '';
+        }
+
+        $schema = [
+            '@context' => 'https://schema.org',
+            '@type' => 'BreadcrumbList',
+            'itemListElement' => $items,
+        ];
+
+        $json = json_encode($schema, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT);
+
+        return \sprintf('<script type="application/ld+json">%s</script>', $json);
+    }
+}

--- a/src/Twig/JsonLdExtension.php
+++ b/src/Twig/JsonLdExtension.php
@@ -25,8 +25,7 @@ final readonly class JsonLdExtension
     #[AsTwigFunction(name: 'event_json_ld', isSafe: ['html'])]
     public function eventJsonLd(Event $event): string
     {
-        $schema = $this->eventJsonLd->generateEventSchema($event);
-        $json = $this->eventJsonLd->toJson($schema);
+        $json = $this->eventJsonLd->generateEventJsonLd($event);
 
         return \sprintf('<script type="application/ld+json">%s</script>', $json);
     }
@@ -62,7 +61,7 @@ final readonly class JsonLdExtension
             'itemListElement' => $items,
         ];
 
-        $json = json_encode($schema, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT);
+        $json = json_encode($schema, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT);
 
         return \sprintf('<script type="application/ld+json">%s</script>', $json);
     }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -102,45 +102,7 @@ _______     __  _   _ _____ _____ _    _ _______
     <!-- End Google Tag Manager -->
     <script data-ad-client="ca-pub-2072406985754187" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
 
-    <script type="application/ld+json">
-        {
-            "@context": "https://schema.org",
-            "@graph": [
-                {
-                    "@type": "WebSite",
-                    "@id": "{{ url('app_index') }}#website",
-                    "url": "{{ url('app_index') }}",
-                    "name": "By Night",
-                    "publisher": {
-                        "@id": "{{ url('app_index') }}#organization"
-                    },
-                    "potentialAction": {
-                        "@type": "SearchAction",
-                        "target": "{{ url('app_search_index', {q: '{search_term_string}'})|url_decode }}",
-                        "query-input": "required name=search_term_string"
-                    }
-                },
-                {
-                    "@type": "Organization",
-                    "@id": "{{ url('app_index') }}#organization",
-                    "name": "By Night",
-                    "url": "{{ url('app_index') }}",
-                    "logo": "{{ absolute_url(asset('build/images/by-night.png')) }}"
-                    {%- if social_manager.facebookIdPage or social_manager.twitterIdPage -%}
-                    ,"sameAs": [
-                        {%- if social_manager.facebookIdPage -%}
-                        "https://www.facebook.com/{{ social_manager.facebookIdPage }}"
-                        {%- endif -%}
-                        {%- if social_manager.facebookIdPage and social_manager.twitterIdPage -%},{%- endif -%}
-                        {%- if social_manager.twitterIdPage -%}
-                        "https://twitter.com/{{ social_manager.twitterIdPage }}"
-                        {%- endif -%}
-                    ]
-                    {%- endif -%}
-                }
-            ]
-        }
-    </script>
+    {{ site_json_ld() }}
     {% block json_ld '' %}
     {% block head_js_layout '' %}
     {% block head_js '' %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -40,15 +40,18 @@ _______     __  _   _ _____ _____ _    _ _______
     <meta property="og:url" content="{% block og_url url('app_index') %}">
     <meta property="og:locale" content="fr" />
     <meta property="og:image" content="{% block og_image asset('build/images/by-night.png') %}">
+    <meta property="og:image:width" content="{% block og_image_width '1200' %}">
+    <meta property="og:image:height" content="{% block og_image_height '630' %}">
+    <meta property="og:image:alt" content="{{ block('og_title') }}">
     <!-- ./OpenGraph -->
 
     <!-- Twitter -->
     {% if social_manager.twitterIdPage %}
-        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@{{ social_manager.twitterIdPage }}" />
         <meta name="twitter:title" content="{{ block('og_title') }}" />
         <meta name="twitter:description" content="{{ block('og_description') }}" />
-        <meta name="twitter:image:src" content="{{ block('og_image') }}" />
+        <meta name="twitter:image" content="{{ block('og_image') }}" />
     {% endif %}
     {% block twitter '' %}
     <!-- ./Twitter -->
@@ -101,21 +104,48 @@ _______     __  _   _ _____ _____ _    _ _______
 
     <script type="application/ld+json">
         {
-            "@context": "http://schema.org",
-            "@type": "WebSite",
-            "url": "{{ url('app_index') }}",
-            "potentialAction": {
-                "@type": "SearchAction",
-                "target": "{{ url('app_search_index', {q: '{search_term_string}'})|url_decode }}",
-                "query-input": "required name=search_term_string"
-            }
+            "@context": "https://schema.org",
+            "@graph": [
+                {
+                    "@type": "WebSite",
+                    "@id": "{{ url('app_index') }}#website",
+                    "url": "{{ url('app_index') }}",
+                    "name": "By Night",
+                    "publisher": {
+                        "@id": "{{ url('app_index') }}#organization"
+                    },
+                    "potentialAction": {
+                        "@type": "SearchAction",
+                        "target": "{{ url('app_search_index', {q: '{search_term_string}'})|url_decode }}",
+                        "query-input": "required name=search_term_string"
+                    }
+                },
+                {
+                    "@type": "Organization",
+                    "@id": "{{ url('app_index') }}#organization",
+                    "name": "By Night",
+                    "url": "{{ url('app_index') }}",
+                    "logo": "{{ absolute_url(asset('build/images/by-night.png')) }}"
+                    {%- if social_manager.facebookIdPage or social_manager.twitterIdPage -%}
+                    ,"sameAs": [
+                        {%- if social_manager.facebookIdPage -%}
+                        "https://www.facebook.com/{{ social_manager.facebookIdPage }}"
+                        {%- endif -%}
+                        {%- if social_manager.facebookIdPage and social_manager.twitterIdPage -%},{%- endif -%}
+                        {%- if social_manager.twitterIdPage -%}
+                        "https://twitter.com/{{ social_manager.twitterIdPage }}"
+                        {%- endif -%}
+                    ]
+                    {%- endif -%}
+                }
+            ]
         }
-
     </script>
+    {% block json_ld '' %}
     {% block head_js_layout '' %}
     {% block head_js '' %}
 </head>
-<body itemscope itemtype="http://schema.org/WebPage" id="{% block page_id 'page' %}">
+<body id="{% block page_id 'page' %}">
 <div class="page">
     <!-- Menu -->
     {{ include('fragments/header.html.twig') }}
@@ -128,6 +158,7 @@ _______     __  _   _ _____ _____ _    _ _______
 
                 {% block breadcrumb '' %}
                 {{ wo_render_breadcrumbs({separator: null, listClass: 'breadcrumb', itemClass: 'breadcrumb-item'}) }}
+                {{ breadcrumb_json_ld(menu) }}
             </div>
         </div>
     {% endblock %}

--- a/templates/components/Dates.html.twig
+++ b/templates/components/Dates.html.twig
@@ -4,10 +4,10 @@
 
 {% if to == null or (to != null and startDate == endDate) %}
     Le
-    <time itemprop="startDate" datetime="{{ from|date('Y-m-d\TH:i:sO') }}">{{ from|format_date('full') }}</time>
+    <time datetime="{{ from|date('Y-m-d\TH:i:sO') }}">{{ from|format_date('full') }}</time>
 {% else %}
     Du
-    <time itemprop="startDate" datetime="{{ from|date('Y-m-d\TH:i:sO') }}">{{ from|format_date('full') }}</time>
+    <time datetime="{{ from|date('Y-m-d\TH:i:sO') }}">{{ from|format_date('full') }}</time>
     au
-    <time itemprop="endDate" datetime="{{ to|date('Y-m-d\TH:i:sO') }}">{{ to|format_date('full') }}</time>
+    <time datetime="{{ to|date('Y-m-d\TH:i:sO') }}">{{ to|format_date('full') }}</time>
 {% endif %}

--- a/templates/form/macros.html.twig
+++ b/templates/form/macros.html.twig
@@ -4,12 +4,12 @@
 
     {% if to == null or (to != null and startDate == endDate) %}
         Le
-        <time itemprop="startDate" datetime="{{ from|date('Y-m-d\TH:i:sO') }}">{{ from|format_date('full') }}</time>
+        <time datetime="{{ from|date('Y-m-d\TH:i:sO') }}">{{ from|format_date('full') }}</time>
     {% else %}
         Du
-        <time itemprop="startDate" datetime="{{ from|date('Y-m-d\TH:i:sO') }}">{{ from|format_date('full') }}</time>
+        <time datetime="{{ from|date('Y-m-d\TH:i:sO') }}">{{ from|format_date('full') }}</time>
         au
-        <time itemprop="endDate" datetime="{{ to|date('Y-m-d\TH:i:sO') }}">{{ to|format_date('full') }}</time>
+        <time datetime="{{ to|date('Y-m-d\TH:i:sO') }}">{{ to|format_date('full') }}</time>
     {% endif %}
 {% endmacro %}
 

--- a/templates/location/event/index.html.twig
+++ b/templates/location/event/index.html.twig
@@ -50,6 +50,10 @@
 {% block og_url url('app_event_details', {slug: event.slug, id: event.id, location: event.locationSlug}) %}
 {% block og_image original %}
 
+{% block json_ld %}
+    {{ event_json_ld(event) }}
+{% endblock %}
+
 {% block body -%}
     {% if event.draft %}
         <div class="alert alert-warning">
@@ -63,13 +67,13 @@
                     <div class="col-12">
                         <div class="alert alert-warning mb-0">
                             <twig:Icon name="lucide:triangle-alert" />
-                            <span itemprop="eventStatus">Informations de dernière minute : {{ event.status }}</span>
+                            <span>Informations de dernière minute : {{ event.status }}</span>
                         </div>
                     </div>
                 {% endif %}
                 <div class="col-lg-7">
                     <a class="image-gallery" href="{{ original }}" title="{{ eventShortName }}">
-                        <twig:EventThumb event="{{ event }}" width="{{ 800 }}" placeholderPriority="{{ true }}" class="img" itemprop="image" />
+                        <twig:EventThumb event="{{ event }}" width="{{ 800 }}" placeholderPriority="{{ true }}" class="img" />
                     </a>
                 </div>
                 <div class="col-lg-5 event-details">
@@ -79,15 +83,12 @@
                             <h2>
                                 {% if event.endDate == null or event.startDate == event.endDate %}
                                     Le
-                                    <time itemprop="startDate"
-                                          datetime="{{ event.startDate|date('Y-m-d\\TH:i:sO') }}">{{ event.startDate|format_date('full') }}</time>
+                                    <time datetime="{{ event.startDate|date('Y-m-d\\TH:i:sO') }}">{{ event.startDate|format_date('full') }}</time>
                                 {% else %}
                                     Du
-                                    <time itemprop="startDate"
-                                          datetime="{{ event.startDate|date('Y-m-d\\TH:i:sO') }}">{{ event.startDate|format_date('full') }}</time>
+                                    <time datetime="{{ event.startDate|date('Y-m-d\\TH:i:sO') }}">{{ event.startDate|format_date('full') }}</time>
                                     au
-                                    <time itemprop="endDate"
-                                          datetime="{{ event.endDate|date('Y-m-d\\TH:i:sO') }}">{{ event.endDate|format_date('full') }}</time>
+                                    <time datetime="{{ event.endDate|date('Y-m-d\\TH:i:sO') }}">{{ event.endDate|format_date('full') }}</time>
                                 {% endif %}
                             </h2>
                         </div>
@@ -132,9 +133,7 @@
                             </div>
                         {% endif %}
 
-                        <div itemprop="location" itemscope itemtype="http://schema.org/Place" class="detail-item">
-                            <meta name="url" content="{{ path('app_agenda_by_place', {placeSlug: place.slug, location: place.locationSlug}) }}">
-
+                        <div class="detail-item">
                             {% if event.placeName %}
                                 <twig:Icon name="lucide:map-pin" />
                             {% endif %}
@@ -144,31 +143,26 @@
                                 {% if event.placeName %}
                                     {% set mapValue = event.placeName %}
                                     <h2 class="mb-0">
-                                        <strong class="font-weight-normal" itemprop="name">{{ event.placeName }}</strong>
+                                        <strong class="font-weight-normal">{{ event.placeName }}</strong>
                                     </h2>
                                 {% endif %}
 
                                 {% if event.placeCity %}
-                                    <div itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
-                                        {% if event.place and event.place.city %}
-                                            <meta itemprop="addressCountry" content="{{ event.place.city.country.id }}" />
-                                        {% endif %}
-
+                                    <div>
                                         {% if event.placeStreet %}
-                                            <div itemprop="streetAddress">{{ event.placeStreet }}</div>
+                                            <div>{{ event.placeStreet }}</div>
                                         {% endif %}
 
                                         {% if event.placeCity or event.placePostalCode %}
                                             <div>
                                                 {% if event.placePostalCode %}
-                                                    <span itemprop="postalCode">{{ event.placePostalCode }}</span>
+                                                    <span>{{ event.placePostalCode }}</span>
                                                 {% endif %}
 
                                                 {% if event.placeCity %}
                                                     {% set mapValue = mapValue ~ ' ' ~ event.placeCity %}
                                                     {% if event.place and event.place.city %}
-                                                        <meta name="url" content="{{ path('app_agenda_index', {location: place.locationSlug}) }}">
-                                                        <strong class="font-weight-normal" itemprop="addressLocality">{{ event.placeCity }}</strong>
+                                                        <strong class="font-weight-normal">{{ event.placeCity }}</strong>
                                                     {% endif %}
                                                 {% endif %}
                                             </div>
@@ -177,10 +171,6 @@
                                 {% endif %}
 
                                 {% if event.latitude and event.longitude %}
-                                    <span itemprop="geo" itemscope itemtype="http://schema.org/GeoCoordinates">
-                                        <meta itemprop="latitude" content="{{ event.latitude }}" />
-                                        <meta itemprop="longitude" content="{{ event.longitude }}" />
-                                    </span>
                                     {% if not place.city %}
                                         {% set mapParameter = 'place?q=' %}
                                         {% set mapValue = event.latitude ~ ',' ~ event.longitude %}
@@ -226,7 +216,7 @@
             </div>
             <div class="card-body">
                 <div class="row">
-                    <div itemprop="description" class="col-sm-8">
+                    <div class="col-sm-8">
                         {{ eventDescription|raw }}
                     </div>
                     <div class="col-sm-4 my-3 my-md-0 event-details">

--- a/templates/partials/event/_item-card.html.twig
+++ b/templates/partials/event/_item-card.html.twig
@@ -1,19 +1,12 @@
-{% if microdata is not defined %}
-    {% set microdata = true %}
-{% endif %}
-
-<div class="card card-event card-layout {{ cardLayout|default('') }} row g-0 scroll-item" {% if microdata %}itemscope itemtype="http://schema.org/Event"{% endif %}>
+<div class="card card-event card-layout {{ cardLayout|default('') }} row g-0 scroll-item">
     {% if event.status %}
         <div class="col-12 alert alert-warning mb-0">
             <twig:Icon name="lucide:triangle-alert" />
-            <span {% if microdata %}itemprop="eventStatus"{% endif %}>{{ event.status }}</span>
+            <span>{{ event.status }}</span>
         </div>
     {% endif %}
     <div class="col-sm-3 col-lg-4 card-img-container">
         {% set original = eventProfilePicture.originalPicture(event) %}
-        {% if microdata %}
-            <meta itemprop="image" content="{{ original }}" />
-        {% endif %}
         <div class="image-container">
             <a class="image-gallery" href="{{ original }}" title="{{ event.name }}">
                 <twig:EventThumb event="{{ event }}" width="{{ 360 }}" lazy="{{ true }}" />
@@ -24,9 +17,8 @@
         <div class="card-body">
             <h3 class="h5">
                 <a title="Tous les détails de {{ event.name }}"
-                   href="{{ path('app_event_details', {slug: event.slug, id: event.id, location: event.locationSlug}) }}"
-                   {% if microdata %}itemprop="url"{% endif %}>
-                    <span {% if microdata %}itemprop="name"{% endif %}>{{ event.name }}</span>
+                   href="{{ path('app_event_details', {slug: event.slug, id: event.id, location: event.locationSlug}) }}">
+                    <span>{{ event.name }}</span>
                 </a>
             </h3>
             <div class="detail-item">
@@ -36,23 +28,16 @@
                 <twig:Icon name="lucide:calendar-days" />
                 <div>
                     {% if event.endDate == null or event.startDate == event.endDate %}
-                        {% if microdata %}
-                            <meta itemprop="endDate" content="{{ event.startDate|date('Y-m-d\\TH:i:sO') }}" />
-                        {% endif %}
-
-                        <time {% if microdata %}itemprop="startDate"{% endif %}
-                              datetime="{{ event.startDate|date('Y-m-d\\TH:i:sO') }}">
+                        <time datetime="{{ event.startDate|date('Y-m-d\\TH:i:sO') }}">
                             {{ startDate }}
                         </time>
                     {% else %}
-                        <time {% if microdata %}itemprop="startDate"{% endif %}
-                              datetime="{{ event.startDate|date('Y-m-d\\TH:i:sO') }}">
+                        <time datetime="{{ event.startDate|date('Y-m-d\\TH:i:sO') }}">
                             {{ startDate }}
                         </time>
                         -
 
-                        <time {% if microdata %}itemprop="endDate"{% endif %}
-                              datetime="{{ event.endDate|date('Y-m-d\\TH:i:sO') }}">
+                        <time datetime="{{ event.endDate|date('Y-m-d\\TH:i:sO') }}">
                             {{ endDate }}
                         </time>
                     {% endif %}
@@ -68,34 +53,15 @@
             </div>
             {% set place = event.place %}
             {% if event.placeName %}
-                <div class="detail-item" {% if microdata %}itemprop="location" itemscope itemtype="http://schema.org/Place"{% endif %}>
+                <div class="detail-item">
                     <twig:Icon name="lucide:map-pin" />
                     <div>
-                        <span {% if microdata %}itemprop="name"{% endif %} title="Sortir à {{ event.placeName }}">
+                        <span title="Sortir à {{ event.placeName }}">
                             <strong class="font-weight-normal">{{ event.placeName }}</strong>
                         </span>
-                        {% if microdata and event.latitude and event.longitude %}
-                            <span itemprop="geo" itemscope itemtype="http://schema.org/GeoCoordinates">
-                                <meta itemprop="latitude" content="{{ event.latitude }}" />
-                                <meta itemprop="longitude" content="{{ event.longitude }}" />
-                            </span>
-                        {% endif %}
                         {% if event.placeCity %}
-                            <span {% if microdata %}itemprop="address" itemscope itemtype="http://schema.org/PostalAddress"{% endif %}>,
-                                <span {% if microdata %}itemprop="addressLocality"{% endif %}>{{ event.placeCity }}</span>
-                                {% if microdata %}
-                                    {% if event.placePostalCode %}
-                                        <meta itemprop="addressRegion" content="{{ event.placePostalCode }}" />
-                                    {% endif %}
-
-                                    {% if event.placeStreet %}
-                                    <meta itemprop="streetAddress" content="{{ event.placeStreet }}" />
-                                {% endif %}
-
-                                    {% if event.placeCountry %}
-                                    <meta itemprop="addressCountry" content="{{ event.placeCountry.id }}" />
-                                {% endif %}
-                                {% endif %}
+                            <span>,
+                                <span>{{ event.placeCity }}</span>
                             </span>
                         {% endif %}
                     </div>


### PR DESCRIPTION
## Summary
- Migrate event structured data from schema.org microdata to JSON-LD format
- Add new `EventJsonLd` service and `JsonLdExtension` Twig extension
- Add Organization and BreadcrumbList JSON-LD schemas to base template
- Improve OpenGraph meta tags (og:image dimensions) and upgrade Twitter card to summary_large_image
- Remove all microdata attributes from templates for cleaner HTML

## Test plan
- [ ] Verify JSON-LD appears in `<head>` on event detail pages
- [ ] Test with Google Rich Results Test: https://search.google.com/test/rich-results
- [ ] Confirm no `itemscope`/`itemprop` attributes remain in HTML

🤖 Generated with [Claude Code](https://claude.ai/code)