### PR TITLE
feat: add Billets Reduc and CDiscount Awin parsers

### DIFF
--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -13,6 +13,8 @@ namespace App\Entity;
 use App\Contracts\ExternalIdentifiableInterface;
 use App\Contracts\InternalIdentifiableInterface;
 use App\Contracts\PrefixableObjectKeyInterface;
+use App\Parser\Common\BilletsReducAwinParser;
+use App\Parser\Common\CDiscountAwinParser;
 use App\Parser\Common\DigitickAwinParser;
 use App\Parser\Common\FnacSpectaclesAwinParser;
 use App\Reject\Reject;
@@ -385,6 +387,8 @@ class Event implements Stringable, ExternalIdentifiableInterface, InternalIdenti
         return \in_array($this->fromData, [
             FnacSpectaclesAwinParser::getParserName(),
             DigitickAwinParser::getParserName(),
+            BilletsReducAwinParser::getParserName(),
+            CDiscountAwinParser::getParserName(),
         ], true);
     }
 

--- a/src/Parser/Common/AbstractAwinParser.php
+++ b/src/Parser/Common/AbstractAwinParser.php
@@ -14,6 +14,7 @@ use App\Dto\EventDto;
 use App\Handler\EventHandler;
 use App\Parser\AbstractParser;
 use App\Producer\EventProducer;
+use Generator;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -50,9 +51,9 @@ abstract class AbstractAwinParser extends AbstractParser
     }
 
     /**
-     * @return \Generator<array<string, string>>
+     * @return Generator<array<string, string>>
      */
-    private function parseCsvFile(string $path): \Generator
+    private function parseCsvFile(string $path): Generator
     {
         $handle = gzopen($path, 'r');
 

--- a/src/Parser/Common/AbstractAwinParser.php
+++ b/src/Parser/Common/AbstractAwinParser.php
@@ -15,6 +15,7 @@ use App\Handler\EventHandler;
 use App\Parser\AbstractParser;
 use App\Producer\EventProducer;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
@@ -42,13 +43,13 @@ abstract class AbstractAwinParser extends AbstractParser
         $handle = gzopen($path, 'r');
 
         if (false === $handle) {
-            throw new \RuntimeException(\sprintf('Unable to open gzipped file: %s', $path));
+            throw new RuntimeException(\sprintf('Unable to open gzipped file: %s', $path));
         }
 
         try {
             $headers = fgetcsv($handle);
             if (false === $headers) {
-                throw new \RuntimeException('Unable to read CSV headers');
+                throw new RuntimeException('Unable to read CSV headers');
             }
 
             while (false !== ($row = fgetcsv($handle))) {

--- a/src/Parser/Common/BilletsReducAwinParser.php
+++ b/src/Parser/Common/BilletsReducAwinParser.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Parser\Common;
+
+use App\Dto\CityDto;
+use App\Dto\CountryDto;
+use App\Dto\EventDto;
+use App\Dto\PlaceDto;
+use DateTimeImmutable;
+
+final class BilletsReducAwinParser extends AbstractAwinParser
+{
+    private const string DATAFEED_URL = 'https://productdata.awin.com/datafeed/download/apikey/%key%/fid/47175/format/csv/language/fr/compression/gzip/columns/aw_deep_link,merchant_product_id,product_name,description,merchant_image_url,valid_to,search_price,is_for_sale,custom_1,custom_3,product_short_description,Tickets%3Avenue_name,Tickets%3Alongitude,Tickets%3Alatitude,Tickets%3Aevent_location_address,Tickets%3Aevent_location_city/';
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getParserName(): string
+    {
+        return 'Billets Reduc';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCommandName(): string
+    {
+        return 'awin.billetsreduc';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getAwinUrl(): string
+    {
+        return self::DATAFEED_URL;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function arrayToDto(array $data): ?EventDto
+    {
+        $venueName = trim($data['Tickets:venue_name'] ?? '');
+        if ('0' === $data['is_for_sale'] || '' === $venueName) {
+            return null;
+        }
+
+        // Parse sessions from custom_3 (JSON array with SessionDate)
+        $sessions = json_decode($data['custom_3'] ?? '[]', true);
+        if (!\is_array($sessions) || [] === $sessions) {
+            return null;
+        }
+
+        // Find the earliest non-sold-out session date as start date
+        $startDate = null;
+        $seenHours = [];
+        foreach ($sessions as $session) {
+            if (!isset($session['SessionDate'])) {
+                continue;
+            }
+
+            // Skip sold out sessions
+            if (($session['SoldOut'] ?? 0) === 1) {
+                continue;
+            }
+
+            $sessionDate = DateTimeImmutable::createFromFormat('Y-m-d\TH:i:s', $session['SessionDate']);
+            if (false === $sessionDate) {
+                continue;
+            }
+
+            if (null === $startDate || $sessionDate < $startDate) {
+                $startDate = $sessionDate;
+            }
+
+            $seenHours[] = \sprintf('À %s', $sessionDate->format('H\hi'));
+        }
+
+        if (null === $startDate) {
+            return null;
+        }
+
+        // Parse end date from valid_to (M/d/YYYY h:mm:ss AM/PM format)
+        $endDate = DateTimeImmutable::createFromFormat('n/j/Y g:i:s A', $data['valid_to']);
+        if (false === $endDate) {
+            $endDate = $startDate;
+        }
+
+        // Determine hours display
+        $hours = null;
+        $seenHours = array_unique($seenHours);
+        if (1 === \count($seenHours)) {
+            $hours = $seenHours[0];
+        }
+
+        // Prevents Reject::BAD_EVENT_DATE_INTERVAL
+        $endDate = $endDate->setTime(0, 0);
+        $startDate = $startDate->setTime(0, 0);
+
+        $event = new EventDto();
+        $event->fromData = self::getParserName();
+        $event->externalId = $data['merchant_product_id'];
+        $event->startDate = $startDate;
+        $event->endDate = $endDate;
+        $event->hours = $hours;
+        $event->source = $data['aw_deep_link'];
+        $event->name = $data['product_name'];
+        $event->description = nl2br(trim(\sprintf("%s\n\n%s", $data['description'] ?? '', $data['product_short_description'] ?? '')));
+        $event->imageUrl = $this->getHighResImageUrl($data['merchant_image_url'] ?? '');
+        $event->prices = \sprintf('%s€', $data['search_price']);
+        $event->latitude = (float) ($data['Tickets:latitude'] ?? 0);
+        $event->longitude = (float) ($data['Tickets:longitude'] ?? 0);
+
+        // CSV mapping:
+        // - Tickets:venue_name = venue name
+        // - Tickets:event_location_address = street address
+        // - Tickets:event_location_city = city name (e.g., "PARIS 2EME")
+        // - custom_1 = postal code
+        // - custom_2 = region/city name (e.g., "Paris")
+        // - Tickets:event_location_region = region (e.g., "Ile-de-France")
+        $place = new PlaceDto();
+        $place->name = $venueName;
+        $street = trim($data['Tickets:event_location_address'] ?? '');
+        $place->street = \in_array($street, ['.', '-', ''], true) ? null : $street;
+
+        $cityName = trim($data['Tickets:event_location_city'] ?? '');
+        $postalCode = trim($data['custom_1'] ?? '');
+
+        $place->externalId = sha1(\sprintf(
+            '%s %s %s %s',
+            $venueName,
+            $street,
+            $cityName,
+            $postalCode,
+        ));
+
+        $city = new CityDto();
+        $city->name = $cityName;
+        $city->postalCode = $postalCode;
+
+        $country = new CountryDto();
+        $country->code = 'FR';
+
+        $city->country = $country;
+
+        $place->country = $country;
+
+        $place->city = $city;
+
+        $event->place = $place;
+
+        return $event;
+    }
+
+    /**
+     * Upgrade image URL to high resolution version.
+     * BilletsReduc URLs contain /n200/ which can be replaced with /n800/ for larger images.
+     */
+    private function getHighResImageUrl(string $url): string
+    {
+        if ('' === $url) {
+            return '';
+        }
+
+        return str_replace('/n200/', '/n800/', $url);
+    }
+}

--- a/src/Parser/Common/CDiscountAwinParser.php
+++ b/src/Parser/Common/CDiscountAwinParser.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Parser\Common;
+
+use App\Dto\CityDto;
+use App\Dto\CountryDto;
+use App\Dto\EventDto;
+use App\Dto\PlaceDto;
+use DateTimeImmutable;
+
+final class CDiscountAwinParser extends AbstractAwinParser
+{
+    // Note: merchant_image_url returns 404, use aw_image_url instead (200x200 proxied images)
+    private const string DATAFEED_URL = 'https://productdata.awin.com/datafeed/download/apikey/%key%/fid/48133/format/csv/language/fr/delimiter/%2C/compression/gzip/columns/aw_deep_link,aw_image_url,merchant_product_id,product_name,description,search_price,custom_1,custom_2,custom_3,custom_4,custom_6/';
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getParserName(): string
+    {
+        return 'CDiscount';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCommandName(): string
+    {
+        return 'awin.cdiscount';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getAwinUrl(): string
+    {
+        return self::DATAFEED_URL;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function arrayToDto(array $data): ?EventDto
+    {
+        $venueName = trim($data['custom_6'] ?? '');
+        if ('' === $venueName) {
+            return null;
+        }
+
+        // Parse date from custom_1 (format: "le dd/mm/YYYY à HHh")
+        $dateStr = trim($data['custom_1'] ?? '');
+        if ('' === $dateStr) {
+            return null;
+        }
+
+        // Extract date and time from "le 14/02/2020 à 20h" format
+        $hours = null;
+        if (preg_match('#le (\d{2}/\d{2}/\d{4}) à (\d{1,2})h#', $dateStr, $matches)) {
+            $startDate = DateTimeImmutable::createFromFormat('d/m/Y', $matches[1]);
+            $hours = \sprintf('À %sh', $matches[2]);
+        } else {
+            return null;
+        }
+
+        if (false === $startDate) {
+            return null;
+        }
+
+        // No end date available, use start date
+        $endDate = $startDate;
+
+        // Prevents Reject::BAD_EVENT_DATE_INTERVAL
+        $endDate = $endDate->setTime(0, 0);
+        $startDate = $startDate->setTime(0, 0);
+
+        $event = new EventDto();
+        $event->fromData = self::getParserName();
+        $event->externalId = $data['merchant_product_id'];
+        $event->startDate = $startDate;
+        $event->endDate = $endDate;
+        $event->hours = $hours;
+        $event->source = $data['aw_deep_link'];
+        $event->name = $data['product_name'];
+        $event->description = $data['description'] ?? '';
+        $event->imageUrl = $data['aw_image_url'] ?? '';
+        $event->prices = \sprintf('%s€', $data['search_price']);
+
+        // CSV mapping:
+        // - custom_6 = venue name
+        // - custom_4 = street address
+        // - custom_2 = city name (e.g., "Paris")
+        // - custom_3 = postal code
+        $place = new PlaceDto();
+        $place->name = $venueName;
+        $street = trim($data['custom_4'] ?? '');
+        $place->street = \in_array($street, ['.', '-', ''], true) ? null : $street;
+
+        $cityName = trim($data['custom_2'] ?? '');
+        $postalCode = trim($data['custom_3'] ?? '');
+
+        $place->externalId = sha1(\sprintf(
+            '%s %s %s %s',
+            $venueName,
+            $street,
+            $cityName,
+            $postalCode,
+        ));
+
+        $city = new CityDto();
+        $city->name = $cityName;
+        $city->postalCode = $postalCode;
+
+        $country = new CountryDto();
+        $country->code = 'FR';
+
+        $city->country = $country;
+
+        $place->country = $country;
+
+        $place->city = $city;
+
+        $event->place = $place;
+
+        return $event;
+    }
+}

--- a/src/Parser/Common/FnacSpectaclesAwinParser.php
+++ b/src/Parser/Common/FnacSpectaclesAwinParser.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class FnacSpectaclesAwinParser extends AbstractAwinParser
 {
-    private const string DATAFEED_URL = 'https://productdata.awin.com/datafeed/download/apikey/%key%/language/fr/fid/23455/columns/aw_deep_link,product_name,aw_product_id,merchant_product_id,merchant_image_url,description,merchant_category,search_price,is_for_sale,custom_1,valid_to,product_short_description,custom_2,custom_4,custom_6,custom_3,Tickets%3Avenue_address,Tickets%3Alatitude,Tickets%3Alongitude/format/xml-tree/compression/gzip/';
+    private const string DATAFEED_URL = 'https://productdata.awin.com/datafeed/download/apikey/%key%/language/fr/fid/23455/columns/aw_deep_link,product_name,aw_product_id,merchant_product_id,merchant_image_url,description,merchant_category,search_price,is_for_sale,custom_1,valid_to,product_short_description,custom_2,custom_4,custom_6,custom_3,Tickets%3Avenue_address,Tickets%3Alatitude,Tickets%3Alongitude/format/csv/compression/gzip/';
 
     public function __construct(
         LoggerInterface $logger,
@@ -122,8 +122,8 @@ final class FnacSpectaclesAwinParser extends AbstractAwinParser
         $event->description = nl2br(trim(\sprintf("%s\n\n%s", $data['description'], $data['product_short_description'])));
         $event->imageUrl = $this->getImageUrl($data['merchant_image_url']);
         $event->prices = \sprintf('%s€', $data['search_price']);
-        $event->latitude = (float) $data['latitude'];
-        $event->longitude = (float) $data['longitude'];
+        $event->latitude = (float) $data['Tickets:latitude'];
+        $event->longitude = (float) $data['Tickets:longitude'];
 
         $place = new PlaceDto();
         $place->name = $data['custom_2'];
@@ -132,13 +132,13 @@ final class FnacSpectaclesAwinParser extends AbstractAwinParser
             '%s %s %s %s %s',
             $data['custom_2'],
             $data['custom_6'],
-            $data['venue_address'],
+            $data['Tickets:venue_address'],
             $data['custom_4'],
             $data['custom_3'],
         ));
 
         $city = new CityDto();
-        $city->name = $data['venue_address'];
+        $city->name = $data['Tickets:venue_address'];
         $city->postalCode = $data['custom_4'];
 
         $country = new CountryDto();

--- a/src/Parser/Common/FnacSpectaclesAwinParser.php
+++ b/src/Parser/Common/FnacSpectaclesAwinParser.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class FnacSpectaclesAwinParser extends AbstractAwinParser
 {
-    private const string DATAFEED_URL = 'https://productdata.awin.com/datafeed/download/apikey/%key%/language/fr/fid/23455/columns/aw_deep_link,product_name,aw_product_id,merchant_product_id,merchant_image_url,description,merchant_category,search_price,is_for_sale,custom_1,valid_to,product_short_description,custom_2,custom_4,custom_6,custom_3,Tickets%3Avenue_address,Tickets%3Alatitude,Tickets%3Alongitude/format/csv/compression/gzip/';
+    private const string DATAFEED_URL = 'https://productdata.awin.com/datafeed/download/apikey/%key%/language/fr/fid/23455/columns/aw_deep_link,product_name,merchant_product_id,merchant_image_url,description,search_price,is_for_sale,valid_to,product_short_description,custom_3,custom_4,custom_5,custom_7,Tickets%3Avenue_name,Tickets%3Avenue_address,Tickets%3Aevent_date,Tickets%3Alatitude,Tickets%3Alongitude/format/csv/compression/gzip/';
 
     public function __construct(
         LoggerInterface $logger,
@@ -70,41 +70,28 @@ final class FnacSpectaclesAwinParser extends AbstractAwinParser
      */
     protected function arrayToDto(array $data): ?EventDto
     {
-        if ('0' === $data['is_for_sale'] || '' === trim($data['custom_2'] ?? '')) {
+        $venueName = trim($data['Tickets:venue_name'] ?? '');
+        if ('0' === $data['is_for_sale'] || '' === $venueName) {
             return null;
         }
 
-        $seenHours = [];
+        // Parse start date from Tickets:event_date (YYYY-mm-dd format)
+        $startDate = DateTimeImmutable::createFromFormat('Y-m-d', $data['Tickets:event_date']);
+        if (false === $startDate) {
+            return null;
+        }
+
+        // Parse end date from valid_to (YYYY-mm-dd format)
+        $endDate = DateTimeImmutable::createFromFormat('Y-m-d', $data['valid_to']);
+        if (false === $endDate) {
+            $endDate = $startDate;
+        }
+
+        // Parse hours from custom_7 (HH:mm format)
         $hours = null;
-        $startDate = null;
-        $startDates = array_filter(explode(';', (string) $data['custom_1']));
-
-        if ([] === $startDates) {
-            return null;
-        }
-
-        foreach ($startDates as $startDateStr) {
-            $startDate = DateTimeImmutable::createFromFormat('d/m/Y H:i', $startDateStr);
-            if (false !== $startDate) {
-                $seenHours[] = \sprintf('À %s', $startDate->format('H\hi'));
-            }
-        }
-
-        if ([] === $seenHours) {
-            return null;
-        }
-
-        $seenHours = array_unique($seenHours);
-
-        if (1 === \count($seenHours)) {
-            $hours = $seenHours[0];
-        }
-
-        $endDate = DateTimeImmutable::createFromFormat('d/m/Y H:i', $data['valid_to']);
-
-        if ('31/12 23:59' === $startDate->format('d/m H:i') && $startDate->format('d/m/Y') === $endDate->format('d/m/Y')) {
-            $hours = null;
-            $startDate = $startDate->setDate((int) $startDate->format('Y'), 1, 1);
+        $eventTime = trim($data['custom_7'] ?? '');
+        if ('' !== $eventTime) {
+            $hours = \sprintf('À %s', str_replace(':', 'h', $eventTime));
         }
 
         // Prevents Reject::BAD_EVENT_DATE_INTERVAL
@@ -119,30 +106,37 @@ final class FnacSpectaclesAwinParser extends AbstractAwinParser
         $event->hours = $hours;
         $event->source = $data['aw_deep_link'];
         $event->name = $data['product_name'];
-        $event->description = nl2br(trim(\sprintf("%s\n\n%s", $data['description'], $data['product_short_description'])));
-        $event->imageUrl = $this->getImageUrl($data['merchant_image_url']);
+        $event->description = nl2br(trim(\sprintf("%s\n\n%s", $data['description'] ?? '', $data['product_short_description'] ?? '')));
+        $event->imageUrl = $this->getImageUrl($data['merchant_image_url'] ?? '');
         $event->prices = \sprintf('%s€', $data['search_price']);
-        $event->latitude = (float) $data['Tickets:latitude'];
-        $event->longitude = (float) $data['Tickets:longitude'];
+        $event->latitude = (float) ($data['Tickets:latitude'] ?? 0);
+        $event->longitude = (float) ($data['Tickets:longitude'] ?? 0);
 
+        // CSV mapping:
+        // - Tickets:venue_name = venue name
+        // - Tickets:venue_address = city name
+        // - custom_3 = postal code
+        // - custom_4 = street address
+        // - custom_5 = country code (FR)
         $place = new PlaceDto();
-        $place->name = $data['custom_2'];
-        $place->street = \in_array($data['custom_6'], ['.', '-', ''], true) ? null : $data['custom_6'];
+        $place->name = $venueName;
+        $street = trim($data['custom_4'] ?? '');
+        $place->street = \in_array($street, ['.', '-', ''], true) ? null : $street;
         $place->externalId = sha1(\sprintf(
             '%s %s %s %s %s',
-            $data['custom_2'],
-            $data['custom_6'],
-            $data['Tickets:venue_address'],
-            $data['custom_4'],
-            $data['custom_3'],
+            $venueName,
+            $street,
+            $data['Tickets:venue_address'] ?? '',
+            $data['custom_3'] ?? '',
+            $data['custom_5'] ?? '',
         ));
 
         $city = new CityDto();
-        $city->name = $data['Tickets:venue_address'];
-        $city->postalCode = $data['custom_4'];
+        $city->name = $data['Tickets:venue_address'] ?? '';
+        $city->postalCode = $data['custom_3'] ?? '';
 
         $country = new CountryDto();
-        $country->name = $data['custom_3'];
+        $country->code = $data['custom_5'] ?? '';
 
         $city->country = $country;
 

--- a/src/Picture/EventProfilePicture.php
+++ b/src/Picture/EventProfilePicture.php
@@ -13,6 +13,8 @@ namespace App\Picture;
 use App\Dto\EventDto;
 use App\Entity\Event;
 use App\Helper\AssetHelper;
+use App\Parser\Common\BilletsReducAwinParser;
+use App\Parser\Common\CDiscountAwinParser;
 use App\Parser\Common\DataTourismeParser;
 use App\Parser\Common\DigitickAwinParser;
 use App\Parser\Common\OpenAgendaParser;
@@ -130,6 +132,20 @@ final readonly class EventProfilePicture
         if ($fromData === DigitickAwinParser::getParserName()) {
             return [
                 'path' => $this->packages->getUrl('build/images/parsers/digitick.jpg', 'local'),
+                'source' => 'local',
+            ];
+        }
+
+        if ($fromData === BilletsReducAwinParser::getParserName()) {
+            return [
+                'path' => $this->packages->getUrl('build/images/parsers/billets-reduc.jpg', 'local'),
+                'source' => 'local',
+            ];
+        }
+
+        if ($fromData === CDiscountAwinParser::getParserName()) {
+            return [
+                'path' => $this->packages->getUrl('build/images/parsers/cdiscount.jpg', 'local'),
                 'source' => 'local',
             ];
         }


### PR DESCRIPTION
## Summary
- Refactored AbstractAwinParser to use CSV format instead of XML for better performance and simpler parsing
- Updated FnacSpectaclesAwinParser for the new CSV column mappings
- Added BilletsReducAwinParser with high-resolution image support (n800)
- Added CDiscountAwinParser using aw_image_url (merchant images return 404)

## Test plan
- [ ] Run `bin/console app:events:import awin.fnac -vv` and verify events are imported
- [ ] Run `bin/console app:events:import awin.billetsreduc -vv` and verify events are imported
- [ ] Run `bin/console app:events:import awin.cdiscount -vv` and verify events are imported

🤖 Generated with [Claude Code](https://claude.com/claude-code)