### PR TITLE
refactor: replace mutable DateTime with immutable DateTimeImmutable

### DIFF
--- a/src/Command/ImagesUpdateCommand.php
+++ b/src/Command/ImagesUpdateCommand.php
@@ -12,7 +12,7 @@ namespace App\Command;
 
 use App\Updater\UserUpdater;
 use App\Utils\Monitor;
-use DateTime;
+use DateTimeImmutable;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -40,7 +40,7 @@ final class ImagesUpdateCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $from = new DateTime($input->getOption('from'));
+        $from = new DateTimeImmutable($input->getOption('from'));
 
         Monitor::writeln('Mise à jour des images <info>utilisateur</info>');
         $this->userUpdater->update($from);

--- a/src/Controller/HomeController.php
+++ b/src/Controller/HomeController.php
@@ -13,7 +13,7 @@ namespace App\Controller;
 use App\App\CityManager;
 use App\Form\Type\CityAutocompleteType;
 use App\Repository\EventRepository;
-use DateTime;
+use DateTimeImmutable;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -24,7 +24,7 @@ final class HomeController extends AbstractController
     public function index(Request $request, CityManager $cityManager, EventRepository $eventRepository): Response
     {
         $datas = [
-            'from' => new DateTime(),
+            'from' => new DateTimeImmutable(),
         ];
         if (null !== ($city = $cityManager->getCity())) {
             $datas += [

--- a/src/Controller/PersonalSpace/EventController.php
+++ b/src/Controller/PersonalSpace/EventController.php
@@ -22,7 +22,7 @@ use App\Form\Type\EventType;
 use App\Repository\EventRepository;
 use App\Security\Voter\EventVoter;
 use App\Validator\Constraints\EventConstraintValidator;
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -105,7 +105,7 @@ final class EventController extends BaseController
     public function edit(Request $request, Event $event, EventConstraintValidator $validator, EventDtoFactory $eventDtoFactory): Response
     {
         if ($event->getExternalId()) {
-            $event->setExternalUpdatedAt(new DateTime());
+            $event->setExternalUpdatedAt(new DateTimeImmutable());
         }
 
         $dto = $eventDtoFactory->create($event);

--- a/src/Controller/User/UserController.php
+++ b/src/Controller/User/UserController.php
@@ -14,7 +14,7 @@ use App\Controller\AbstractController as BaseController;
 use App\Entity\User;
 use App\Manager\UserRedirectManager;
 use App\Repository\EventRepository;
-use DateTime;
+use DateTimeImmutable;
 use IntlDateFormatter;
 use Locale;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -110,7 +110,7 @@ final class UserController extends BaseController
         ];
 
         foreach (range(1, 7) as $day) {
-            $date = new DateTime('0' . $day . '-01-' . date('Y'));
+            $date = new DateTimeImmutable('0' . $day . '-01-' . date('Y'));
             $dayNumber = $date->format('w');
             $dateFormatter = IntlDateFormatter::create(
                 Locale::getDefault(),
@@ -158,7 +158,7 @@ final class UserController extends BaseController
         ];
 
         foreach (range(1, 12) as $month) {
-            $date = new DateTime('01-' . $month . '-' . date('Y'));
+            $date = new DateTimeImmutable('01-' . $month . '-' . date('Y'));
             $dateFormatter = IntlDateFormatter::create(
                 Locale::getDefault(),
                 IntlDateFormatter::NONE,

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -18,7 +18,6 @@ use App\Parser\Common\FnacSpectaclesAwinParser;
 use App\Reject\Reject;
 use App\Repository\EventRepository;
 use App\Utils\UnitOfWorkOptimizer;
-use DateTime;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -76,19 +75,19 @@ class Event implements Stringable, ExternalIdentifiableInterface, InternalIdenti
     #[Groups(['elasticsearch:event:details'])]
     private ?string $description = null;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
-    private ?DateTime $externalUpdatedAt = null;
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $externalUpdatedAt = null;
 
     #[Assert\NotBlank(message: 'Vous devez donner une date à votre événement')]
-    #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
+    #[ORM\Column(type: Types::DATE_IMMUTABLE, nullable: true)]
     #[Groups(['elasticsearch:event:details'])]
     #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
-    private ?DateTime $startDate;
+    private ?DateTimeImmutable $startDate;
 
-    #[ORM\Column(type: Types::DATE_MUTABLE, nullable: true)]
+    #[ORM\Column(type: Types::DATE_IMMUTABLE, nullable: true)]
     #[Groups(['elasticsearch:event:details'])]
     #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
-    private ?DateTime $endDate = null;
+    private ?DateTimeImmutable $endDate = null;
 
     #[ORM\Column(type: Types::STRING, length: 256, nullable: true)]
     private ?string $hours = null;
@@ -313,7 +312,7 @@ class Event implements Stringable, ExternalIdentifiableInterface, InternalIdenti
 
     public function __construct()
     {
-        $this->startDate = new DateTime();
+        $this->startDate = new DateTimeImmutable();
         $this->userEvents = new ArrayCollection();
         $this->comments = new ArrayCollection();
         $this->timesheets = new ArrayCollection();
@@ -550,36 +549,36 @@ class Event implements Stringable, ExternalIdentifiableInterface, InternalIdenti
         return $this;
     }
 
-    public function getExternalUpdatedAt(): ?DateTime
+    public function getExternalUpdatedAt(): ?DateTimeImmutable
     {
         return $this->externalUpdatedAt;
     }
 
-    public function setExternalUpdatedAt(?DateTime $externalUpdatedAt): self
+    public function setExternalUpdatedAt(?DateTimeImmutable $externalUpdatedAt): self
     {
         $this->externalUpdatedAt = UnitOfWorkOptimizer::getDateTimeValue($this->externalUpdatedAt, $externalUpdatedAt);
 
         return $this;
     }
 
-    public function getStartDate(): ?DateTime
+    public function getStartDate(): ?DateTimeImmutable
     {
         return $this->startDate;
     }
 
-    public function setStartDate(?DateTime $startDate): self
+    public function setStartDate(?DateTimeImmutable $startDate): self
     {
         $this->startDate = UnitOfWorkOptimizer::getDateValue($this->startDate, $startDate);
 
         return $this;
     }
 
-    public function getEndDate(): ?DateTime
+    public function getEndDate(): ?DateTimeImmutable
     {
         return $this->endDate;
     }
 
-    public function setEndDate(?DateTime $endDate): self
+    public function setEndDate(?DateTimeImmutable $endDate): self
     {
         $this->endDate = UnitOfWorkOptimizer::getDateValue($this->endDate, $endDate);
 

--- a/src/Entity/EventTimesheet.php
+++ b/src/Entity/EventTimesheet.php
@@ -11,7 +11,7 @@
 namespace App\Entity;
 
 use App\Utils\UnitOfWorkOptimizer;
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Stringable;
@@ -32,15 +32,15 @@ class EventTimesheet implements Stringable
     #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
     private ?Event $event = null;
 
-    #[ORM\Column(type: Types::DATE_MUTABLE)]
+    #[ORM\Column(type: Types::DATE_IMMUTABLE)]
     #[Groups(['elasticsearch:event:details'])]
     #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
-    private ?DateTime $startAt = null;
+    private ?DateTimeImmutable $startAt = null;
 
-    #[ORM\Column(type: Types::DATE_MUTABLE)]
+    #[ORM\Column(type: Types::DATE_IMMUTABLE)]
     #[Groups(['elasticsearch:event:details'])]
     #[Context([DateTimeNormalizer::FORMAT_KEY => 'Y-m-d'])]
-    private ?DateTime $endAt = null;
+    private ?DateTimeImmutable $endAt = null;
 
     #[ORM\Column(type: Types::STRING, length: 256, nullable: true)]
     private ?string $hours = null;
@@ -65,24 +65,24 @@ class EventTimesheet implements Stringable
         return $this;
     }
 
-    public function getStartAt(): ?DateTime
+    public function getStartAt(): ?DateTimeImmutable
     {
         return $this->startAt;
     }
 
-    public function setStartAt(?DateTime $startAt): self
+    public function setStartAt(?DateTimeImmutable $startAt): self
     {
         $this->startAt = UnitOfWorkOptimizer::getDateTimeValue($this->startAt, $startAt);
 
         return $this;
     }
 
-    public function getEndAt(): ?DateTime
+    public function getEndAt(): ?DateTimeImmutable
     {
         return $this->endAt;
     }
 
-    public function setEndAt(?DateTime $endAt): self
+    public function setEndAt(?DateTimeImmutable $endAt): self
     {
         $this->endAt = UnitOfWorkOptimizer::getDateTimeValue($this->endAt, $endAt);
 

--- a/src/Entity/ParserData.php
+++ b/src/Entity/ParserData.php
@@ -13,7 +13,7 @@ namespace App\Entity;
 use App\Reject\Reject;
 use App\Repository\ParserDataRepository;
 use App\Utils\UnitOfWorkOptimizer;
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -29,8 +29,8 @@ class ParserData
     #[ORM\Column(type: Types::STRING, length: 63)]
     private ?string $externalOrigin = null;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
-    private ?DateTime $lastUpdated = null;
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $lastUpdated = null;
 
     #[ORM\Column(type: Types::INTEGER)]
     private int $reason = Reject::VALID;
@@ -67,12 +67,12 @@ class ParserData
         return $this;
     }
 
-    public function getLastUpdated(): ?DateTime
+    public function getLastUpdated(): ?DateTimeImmutable
     {
         return $this->lastUpdated;
     }
 
-    public function setLastUpdated(?DateTime $lastUpdated): self
+    public function setLastUpdated(?DateTimeImmutable $lastUpdated): self
     {
         $this->lastUpdated = UnitOfWorkOptimizer::getDateTimeValue($this->lastUpdated, $lastUpdated);
 

--- a/src/Entity/ParserHistory.php
+++ b/src/Entity/ParserHistory.php
@@ -12,7 +12,7 @@ namespace App\Entity;
 
 use App\Repository\ParserHistoryRepository;
 use App\Utils\UnitOfWorkOptimizer;
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -22,11 +22,11 @@ class ParserHistory
 {
     use EntityIdentityTrait;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private DateTime $startDate;
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private DateTimeImmutable $startDate;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private DateTime $endDate;
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private DateTimeImmutable $endDate;
 
     #[ORM\Column(type: Types::STRING, length: 127)]
     private ?string $fromData = null;
@@ -42,14 +42,14 @@ class ParserHistory
 
     public function __construct()
     {
-        $this->startDate = new DateTime();
-        $this->endDate = new DateTime();
+        $this->startDate = new DateTimeImmutable();
+        $this->endDate = new DateTimeImmutable();
     }
 
     #[ORM\PrePersist]
     public function updateEndDate(): void
     {
-        $this->setEndDate(new DateTime());
+        $this->setEndDate(new DateTimeImmutable());
     }
 
     /**
@@ -60,12 +60,12 @@ class ParserHistory
         return $this->endDate->getTimestamp() - $this->startDate->getTimestamp();
     }
 
-    public function getStartDate(): ?DateTime
+    public function getStartDate(): ?DateTimeImmutable
     {
         return $this->startDate;
     }
 
-    public function setStartDate(DateTime $startDate): self
+    public function setStartDate(DateTimeImmutable $startDate): self
     {
         $this->startDate = UnitOfWorkOptimizer::getDateTimeValue($this->startDate, $startDate);
 
@@ -84,12 +84,12 @@ class ParserHistory
         return $this;
     }
 
-    public function getEndDate(): ?DateTime
+    public function getEndDate(): ?DateTimeImmutable
     {
         return $this->endDate;
     }
 
-    public function setEndDate(DateTime $endDate): self
+    public function setEndDate(DateTimeImmutable $endDate): self
     {
         $this->endDate = UnitOfWorkOptimizer::getDateTimeValue($this->endDate, $endDate);
 

--- a/src/Entity/PlaceMetadata.php
+++ b/src/Entity/PlaceMetadata.php
@@ -13,7 +13,7 @@ namespace App\Entity;
 use App\Contracts\ExternalIdentifiableInterface;
 use App\Repository\PlaceMetadataRepository;
 use App\Utils\UnitOfWorkOptimizer;
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Stringable;
@@ -34,8 +34,8 @@ class PlaceMetadata implements ExternalIdentifiableInterface, Stringable
     #[ORM\Column(type: Types::STRING, length: 63)]
     private ?string $externalOrigin = null;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
-    private ?DateTime $externalUpdatedAt = null;
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $externalUpdatedAt = null;
 
     public function __toString(): string
     {
@@ -69,12 +69,12 @@ class PlaceMetadata implements ExternalIdentifiableInterface, Stringable
         return $this;
     }
 
-    public function getExternalUpdatedAt(): ?DateTime
+    public function getExternalUpdatedAt(): ?DateTimeImmutable
     {
         return $this->externalUpdatedAt;
     }
 
-    public function setExternalUpdatedAt(?DateTime $externalUpdatedAt): self
+    public function setExternalUpdatedAt(?DateTimeImmutable $externalUpdatedAt): self
     {
         $this->externalUpdatedAt = UnitOfWorkOptimizer::getDateTimeValue($this->externalUpdatedAt, $externalUpdatedAt);
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -15,7 +15,6 @@ use App\Contracts\PrefixableObjectKeyInterface;
 use App\Doctrine\EntityListener\UserEmailEntityListener;
 use App\Repository\UserRepository;
 use App\Utils\UnitOfWorkOptimizer;
-use DateTime;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -65,11 +64,11 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Seriali
     #[ORM\Column(type: Types::BOOLEAN)]
     private bool $enabled = true;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
-    private ?DateTime $lastLogin;
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $lastLogin;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE, nullable: true)]
-    private ?DateTime $passwordRequestedAt = null;
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $passwordRequestedAt = null;
 
     #[ORM\Column(type: Types::JSON)]
     private array $roles = [];
@@ -147,7 +146,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Seriali
 
     public function __construct()
     {
-        $this->lastLogin = new DateTime();
+        $this->lastLogin = new DateTimeImmutable();
         $this->userEvents = new ArrayCollection();
         $this->oAuth = new UserOAuth();
         $this->image = new EmbeddedFile();
@@ -575,24 +574,24 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Seriali
         return $this;
     }
 
-    public function getLastLogin(): ?DateTime
+    public function getLastLogin(): ?DateTimeImmutable
     {
         return $this->lastLogin;
     }
 
-    public function setLastLogin(?DateTime $lastLogin): self
+    public function setLastLogin(?DateTimeImmutable $lastLogin): self
     {
         $this->lastLogin = UnitOfWorkOptimizer::getDateTimeValue($this->lastLogin, $lastLogin);
 
         return $this;
     }
 
-    public function getPasswordRequestedAt(): ?DateTime
+    public function getPasswordRequestedAt(): ?DateTimeImmutable
     {
         return $this->passwordRequestedAt;
     }
 
-    public function setPasswordRequestedAt(?DateTime $passwordRequestedAt): self
+    public function setPasswordRequestedAt(?DateTimeImmutable $passwordRequestedAt): self
     {
         $this->passwordRequestedAt = UnitOfWorkOptimizer::getDateTimeValue($this->passwordRequestedAt, $passwordRequestedAt);
 

--- a/src/EntityFactory/EventEntityFactory.php
+++ b/src/EntityFactory/EventEntityFactory.php
@@ -19,7 +19,7 @@ use App\Entity\Place;
 use App\Entity\User;
 use App\Handler\EntityProviderHandler;
 use App\Repository\TagRepository;
-use DateTime;
+use DateTimeImmutable;
 
 final readonly class EventEntityFactory implements EntityFactoryInterface
 {
@@ -50,13 +50,13 @@ final readonly class EventEntityFactory implements EntityFactoryInterface
         $entity->setExternalId($dto->externalId);
         $entity->setExternalOrigin($dto->externalOrigin);
 
-        $entity->setExternalUpdatedAt(null === $dto->externalUpdatedAt ? null : DateTime::createFromInterface($dto->externalUpdatedAt));
+        $entity->setExternalUpdatedAt(null === $dto->externalUpdatedAt ? null : DateTimeImmutable::createFromInterface($dto->externalUpdatedAt));
 
         // Sync timesheets from DTO
         $this->syncTimesheets($entity, $dto);
 
-        $entity->setStartDate(null === $dto->startDate ? null : DateTime::createFromInterface($dto->startDate));
-        $entity->setEndDate(null === $dto->endDate ? null : DateTime::createFromInterface($dto->endDate));
+        $entity->setStartDate(null === $dto->startDate ? null : DateTimeImmutable::createFromInterface($dto->startDate));
+        $entity->setEndDate(null === $dto->endDate ? null : DateTimeImmutable::createFromInterface($dto->endDate));
 
         $entity->setAddress($dto->address);
         if (null !== $dto->createdAt) {
@@ -157,8 +157,8 @@ final readonly class EventEntityFactory implements EntityFactoryInterface
 
         // Process DTOs: update existing or add new
         foreach ($dto->timesheets as $timesheetDto) {
-            $startAt = null === $timesheetDto->startAt ? null : DateTime::createFromInterface($timesheetDto->startAt);
-            $endAt = null === $timesheetDto->endAt ? null : DateTime::createFromInterface($timesheetDto->endAt);
+            $startAt = null === $timesheetDto->startAt ? null : DateTimeImmutable::createFromInterface($timesheetDto->startAt);
+            $endAt = null === $timesheetDto->endAt ? null : DateTimeImmutable::createFromInterface($timesheetDto->endAt);
             $key = $this->getTimesheetKey($startAt, $endAt);
 
             if (isset($existingMap[$key])) {
@@ -188,7 +188,7 @@ final readonly class EventEntityFactory implements EntityFactoryInterface
     /**
      * Generate a unique key for a timesheet based on start and end dates.
      */
-    private function getTimesheetKey(?DateTime $startAt, ?DateTime $endAt): string
+    private function getTimesheetKey(?DateTimeImmutable $startAt, ?DateTimeImmutable $endAt): string
     {
         $start = $startAt?->format('Y-m-d H:i:s') ?? 'null';
         $end = $endAt?->format('Y-m-d H:i:s') ?? 'null';

--- a/src/EventSubscriber/UserLastLoginSubscriber.php
+++ b/src/EventSubscriber/UserLastLoginSubscriber.php
@@ -11,7 +11,7 @@
 namespace App\EventSubscriber;
 
 use App\Entity\User;
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
@@ -40,7 +40,7 @@ final readonly class UserLastLoginSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $user->setLastLogin(new DateTime());
+        $user->setLastLogin(new DateTimeImmutable());
         $this->entityManager->flush();
     }
 }

--- a/src/Factory/EventFactory.php
+++ b/src/Factory/EventFactory.php
@@ -11,7 +11,7 @@
 namespace App\Factory;
 
 use App\Entity\Event;
-use DateTime;
+use DateTimeImmutable;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 
 /**
@@ -67,7 +67,7 @@ final class EventFactory extends PersistentProxyObjectFactory
         ]);
     }
 
-    public function withDates(DateTime $startDate, ?DateTime $endDate = null): self
+    public function withDates(DateTimeImmutable $startDate, ?DateTimeImmutable $endDate = null): self
     {
         return $this->with([
             'startDate' => $startDate,

--- a/src/Handler/ParserHistoryHandler.php
+++ b/src/Handler/ParserHistoryHandler.php
@@ -11,7 +11,7 @@
 namespace App\Handler;
 
 use App\Entity\ParserHistory;
-use DateTime;
+use DateTimeImmutable;
 
 final class ParserHistoryHandler
 {
@@ -62,7 +62,7 @@ final class ParserHistoryHandler
     {
         $this
             ->parserHistory
-            ->setEndDate(new DateTime())
+            ->setEndDate(new DateTimeImmutable())
             ->setExplorations($this->getNbExplorations() + $this->getNbBlackLists())
             ->setNewEvents($this->getNbInserts())
             ->setUpdatedEvents($this->getNbUpdates())
@@ -93,7 +93,7 @@ final class ParserHistoryHandler
 
     public function start(): void
     {
-        $this->parserHistory = new ParserHistory()->setStartDate(new DateTime());
+        $this->parserHistory = new ParserHistory()->setStartDate(new DateTimeImmutable());
     }
 
     public function reset(): void

--- a/src/Repository/EventRepository.php
+++ b/src/Repository/EventRepository.php
@@ -17,7 +17,7 @@ use App\Entity\Event;
 use App\Entity\Tag;
 use App\Entity\User;
 use App\Entity\UserEvent;
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\QueryBuilder;
@@ -83,8 +83,8 @@ final class EventRepository extends ServiceEntityRepository implements DtoFindab
      */
     public function createIsActiveQueryBuilder(): QueryBuilder
     {
-        $from = new DateTime();
-        $from->modify(Event::INDEX_FROM);
+        $from = new DateTimeImmutable();
+        $from = $from->modify(Event::INDEX_FROM);
 
         $qb = $this->createElasticaQueryBuilder('e');
 
@@ -137,8 +137,8 @@ final class EventRepository extends ServiceEntityRepository implements DtoFindab
 
     public function updateNonIndexables(): void
     {
-        $from = new DateTime();
-        $from->modify(Event::INDEX_FROM);
+        $from = new DateTimeImmutable();
+        $from = $from->modify(Event::INDEX_FROM);
 
         $this
             ->getEntityManager()
@@ -152,9 +152,9 @@ final class EventRepository extends ServiceEntityRepository implements DtoFindab
 
     public function findNonIndexablesBuilder(): QueryBuilder
     {
-        $from = new DateTime();
+        $from = new DateTimeImmutable();
 
-        $from->modify(Event::INDEX_FROM);
+        $from = $from->modify(Event::INDEX_FROM);
 
         return $this
             ->createElasticaQueryBuilder('e')
@@ -175,7 +175,7 @@ final class EventRepository extends ServiceEntityRepository implements DtoFindab
 
     public function getCountryEvents(): array
     {
-        $from = new DateTime();
+        $from = new DateTimeImmutable();
 
         return $this->getEntityManager()
             ->createQueryBuilder()
@@ -333,7 +333,7 @@ final class EventRepository extends ServiceEntityRepository implements DtoFindab
 
     public function findAllNextQueryBuilder(Event $event): QueryBuilder
     {
-        $from = new DateTime();
+        $from = new DateTimeImmutable();
 
         return $this
             ->createQueryBuilder('e')
@@ -346,8 +346,8 @@ final class EventRepository extends ServiceEntityRepository implements DtoFindab
 
     public function findTopEventsQueryBuilder(Location $location): QueryBuilder
     {
-        $du = new DateTime();
-        $au = new DateTime('sunday this week');
+        $du = new DateTimeImmutable();
+        $au = new DateTimeImmutable('sunday this week');
 
         $qb = $this
             ->createQueryBuilder('e')
@@ -372,7 +372,7 @@ final class EventRepository extends ServiceEntityRepository implements DtoFindab
 
     public function findUpcomingEventsQueryBuilder(Location $location): QueryBuilder
     {
-        $from = new DateTime();
+        $from = new DateTimeImmutable();
 
         $qb = $this
             ->createQueryBuilder('e')
@@ -404,8 +404,8 @@ final class EventRepository extends ServiceEntityRepository implements DtoFindab
      */
     public function getEventTypes(Location $location): array
     {
-        $from = new DateTime();
-        $from->modify(Event::INDEX_FROM);
+        $from = new DateTimeImmutable();
+        $from = $from->modify(Event::INDEX_FROM);
 
         $qb = $this->getEntityManager()
             ->createQueryBuilder()

--- a/src/Search/SearchEvent.php
+++ b/src/Search/SearchEvent.php
@@ -11,7 +11,7 @@
 namespace App\Search;
 
 use App\App\Location;
-use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -43,7 +43,7 @@ final class SearchEvent
 
     public function __construct()
     {
-        $this->from = new DateTime();
+        $this->from = new DateTimeImmutable();
     }
 
     /**

--- a/src/Twig/DateExtension.php
+++ b/src/Twig/DateExtension.php
@@ -10,16 +10,16 @@
 
 namespace App\Twig;
 
-use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use Twig\Attribute\AsTwigFilter;
 
 final class DateExtension
 {
     #[AsTwigFilter(name: 'datetime')]
-    public function getDateTime(string $string): DateTime
+    public function getDateTime(string $string): DateTimeImmutable
     {
-        return new DateTime($string);
+        return new DateTimeImmutable($string);
     }
 
     #[AsTwigFilter(name: 'diff_date')]
@@ -36,7 +36,7 @@ final class DateExtension
     #[AsTwigFilter(name: 'stats_diff_date')]
     public function statsDiffDate(DateTimeInterface $date): array
     {
-        $diff = $date->diff(new DateTime());
+        $diff = $date->diff(new DateTimeImmutable());
 
         if ($diff->y > 0) { // Années
             return [

--- a/src/Utils/Firewall.php
+++ b/src/Utils/Firewall.php
@@ -14,7 +14,7 @@ use App\Dto\EventDto;
 use App\Entity\ParserData;
 use App\Reject\Reject;
 use App\Repository\ParserDataRepository;
-use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 
 final class Firewall
@@ -124,7 +124,7 @@ final class Firewall
                 $parserData = new ParserData()
                     ->setExternalId($dto->getExternalId())
                     ->setExternalOrigin($dto->getExternalOrigin())
-                    ->setLastUpdated(null === $dto->getExternalUpdatedAt() ? null : DateTime::createFromInterface($dto->getExternalUpdatedAt()))
+                    ->setLastUpdated(null === $dto->getExternalUpdatedAt() ? null : DateTimeImmutable::createFromInterface($dto->getExternalUpdatedAt()))
                     ->setReject($dto->reject)
                     ->setReason($dto->reject->getReason())
                     ->setFirewallVersion(self::VERSION)
@@ -134,7 +134,7 @@ final class Firewall
             } else {
                 // No need to panic the EM if dates are equivalent
                 if ($parserData->getLastUpdated()?->format('Y-m-d H:i:s') !== $dto->getExternalUpdatedAt()?->format('Y-m-d H:i:s')) {
-                    $parserData->setLastUpdated(null === $dto->getExternalUpdatedAt() ? null : DateTime::createFromInterface($dto->getExternalUpdatedAt()));
+                    $parserData->setLastUpdated(null === $dto->getExternalUpdatedAt() ? null : DateTimeImmutable::createFromInterface($dto->getExternalUpdatedAt()));
                 }
 
                 $parserData

--- a/tests/Entity/EventTest.php
+++ b/tests/Entity/EventTest.php
@@ -12,7 +12,7 @@ namespace App\Tests\Entity;
 
 use App\Entity\Event;
 use App\Entity\EventTimesheet;
-use DateTime;
+use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 
 class EventTest extends TestCase
@@ -20,7 +20,7 @@ class EventTest extends TestCase
     public function testMajEndDateSetsEndDateFromStartDateWhenNoTimesheets(): void
     {
         $event = new Event();
-        $event->setStartDate(new DateTime('2024-01-15'));
+        $event->setStartDate(new DateTimeImmutable('2024-01-15'));
         $event->setEndDate(null);
 
         $event->updateEndDate();
@@ -32,8 +32,8 @@ class EventTest extends TestCase
     public function testMajEndDateDoesNotOverrideExistingEndDateWhenNoTimesheets(): void
     {
         $event = new Event();
-        $event->setStartDate(new DateTime('2024-01-15'));
-        $event->setEndDate(new DateTime('2024-01-20'));
+        $event->setStartDate(new DateTimeImmutable('2024-01-15'));
+        $event->setEndDate(new DateTimeImmutable('2024-01-20'));
 
         $event->updateEndDate();
 
@@ -43,7 +43,7 @@ class EventTest extends TestCase
     public function testMajEndDateHandlesTimesheetsWithNullDates(): void
     {
         $event = new Event();
-        $event->setStartDate(new DateTime('2024-01-01'));
+        $event->setStartDate(new DateTimeImmutable('2024-01-01'));
         $event->setEndDate(null);
 
         // Add a timesheet with null dates (edge case)

--- a/tests/Utils/FirewallTest.php
+++ b/tests/Utils/FirewallTest.php
@@ -16,7 +16,7 @@ use App\Entity\ParserData;
 use App\Reject\Reject;
 use App\Tests\AppKernelTestCase;
 use App\Utils\Firewall;
-use DateTime;
+use DateTimeImmutable;
 use Override;
 
 final class FirewallTest extends AppKernelTestCase
@@ -37,8 +37,8 @@ final class FirewallTest extends AppKernelTestCase
         $badReject = new Reject()->addReason(Reject::BAD_PLACE_LOCATION);
         $deletedReject = new Reject()->addReason(Reject::EVENT_DELETED);
 
-        $now = new DateTime();
-        $tomorrow = new DateTime('tomorrow');
+        $now = new DateTimeImmutable();
+        $tomorrow = new DateTimeImmutable('tomorrow');
 
         // L'événement ne doit pas être valide car il n'a pas changé
         $exploration = new ParserData()->setReject(clone $noNeedToUpdateReject)->setLastUpdated($now);
@@ -102,12 +102,12 @@ final class FirewallTest extends AppKernelTestCase
         $dto = $this->createValidEventDto();
 
         $timesheet1 = new EventTimesheetDto();
-        $timesheet1->startAt = new DateTime('2024-01-15 10:00:00');
-        $timesheet1->endAt = new DateTime('2024-01-15 18:00:00');
+        $timesheet1->startAt = new DateTimeImmutable('2024-01-15 10:00:00');
+        $timesheet1->endAt = new DateTimeImmutable('2024-01-15 18:00:00');
 
         $timesheet2 = new EventTimesheetDto();
-        $timesheet2->startAt = new DateTime('2024-01-20 14:00:00');
-        $timesheet2->endAt = new DateTime('2024-01-20 22:00:00');
+        $timesheet2->startAt = new DateTimeImmutable('2024-01-20 14:00:00');
+        $timesheet2->endAt = new DateTimeImmutable('2024-01-20 22:00:00');
 
         $dto->timesheets = [$timesheet1, $timesheet2];
         $dto->startDate = null;
@@ -125,7 +125,7 @@ final class FirewallTest extends AppKernelTestCase
 
         $timesheet = new EventTimesheetDto();
         $timesheet->startAt = null;
-        $timesheet->endAt = new DateTime('2024-01-15 18:00:00');
+        $timesheet->endAt = new DateTimeImmutable('2024-01-15 18:00:00');
 
         $dto->timesheets = [$timesheet];
 
@@ -139,7 +139,7 @@ final class FirewallTest extends AppKernelTestCase
         $dto = $this->createValidEventDto();
 
         $timesheet = new EventTimesheetDto();
-        $timesheet->startAt = new DateTime('2024-01-15 10:00:00');
+        $timesheet->startAt = new DateTimeImmutable('2024-01-15 10:00:00');
         $timesheet->endAt = null;
 
         $dto->timesheets = [$timesheet];
@@ -154,8 +154,8 @@ final class FirewallTest extends AppKernelTestCase
         $dto = $this->createValidEventDto();
 
         $timesheet = new EventTimesheetDto();
-        $timesheet->startAt = new DateTime('2024-01-15 18:00:00');
-        $timesheet->endAt = new DateTime('2024-01-15 10:00:00'); // End before start
+        $timesheet->startAt = new DateTimeImmutable('2024-01-15 18:00:00');
+        $timesheet->endAt = new DateTimeImmutable('2024-01-15 10:00:00'); // End before start
 
         $dto->timesheets = [$timesheet];
 
@@ -169,12 +169,12 @@ final class FirewallTest extends AppKernelTestCase
         $dto = $this->createValidEventDto();
 
         $validTimesheet = new EventTimesheetDto();
-        $validTimesheet->startAt = new DateTime('2024-01-15 10:00:00');
-        $validTimesheet->endAt = new DateTime('2024-01-15 18:00:00');
+        $validTimesheet->startAt = new DateTimeImmutable('2024-01-15 10:00:00');
+        $validTimesheet->endAt = new DateTimeImmutable('2024-01-15 18:00:00');
 
         $invalidTimesheet = new EventTimesheetDto();
-        $invalidTimesheet->startAt = new DateTime('2024-01-20 18:00:00');
-        $invalidTimesheet->endAt = new DateTime('2024-01-20 10:00:00'); // Invalid
+        $invalidTimesheet->startAt = new DateTimeImmutable('2024-01-20 18:00:00');
+        $invalidTimesheet->endAt = new DateTimeImmutable('2024-01-20 10:00:00'); // Invalid
 
         $dto->timesheets = [$validTimesheet, $invalidTimesheet];
 
@@ -187,8 +187,8 @@ final class FirewallTest extends AppKernelTestCase
     {
         $dto = $this->createValidEventDto();
         $dto->timesheets = [];
-        $dto->startDate = new DateTime('2024-01-15');
-        $dto->endDate = new DateTime('2024-01-20');
+        $dto->startDate = new DateTimeImmutable('2024-01-15');
+        $dto->endDate = new DateTimeImmutable('2024-01-20');
 
         $this->firewall->filterEvent($dto);
 
@@ -200,8 +200,8 @@ final class FirewallTest extends AppKernelTestCase
     {
         $dto = $this->createValidEventDto();
         $dto->timesheets = [];
-        $dto->startDate = new DateTime('2024-01-20');
-        $dto->endDate = new DateTime('2024-01-15'); // End before start
+        $dto->startDate = new DateTimeImmutable('2024-01-20');
+        $dto->endDate = new DateTimeImmutable('2024-01-15'); // End before start
 
         $this->firewall->filterEvent($dto);
 
@@ -214,8 +214,8 @@ final class FirewallTest extends AppKernelTestCase
         $dto->reject = new Reject();
         $dto->name = 'Test Event Name';
         $dto->description = 'This is a valid event description with enough characters.';
-        $dto->startDate = new DateTime('2024-01-15');
-        $dto->endDate = new DateTime('2024-01-20');
+        $dto->startDate = new DateTimeImmutable('2024-01-15');
+        $dto->endDate = new DateTimeImmutable('2024-01-20');
 
         return $dto;
     }


### PR DESCRIPTION
## Summary
- Migrated all mutable `DateTime` usages to immutable `DateTimeImmutable` across entities, repositories, handlers, controllers, and tests
- Updated Doctrine column types from `DATETIME_MUTABLE`/`DATE_MUTABLE` to `DATETIME_IMMUTABLE`/`DATE_IMMUTABLE`
- Fixed method signatures and return types to use `DateTimeImmutable`

## Test plan
- [x] PHPStan passes with no errors
- [x] PHP CS Fixer reports no issues
- [x] PHPUnit tests pass (274 tests, 472 assertions)

🤖 Generated with [Claude Code](https://claude.ai/code)