### PR TITLE
Add PHPDoc generics and remove LOWER() from queries

### DIFF
--- a/src/Repository/CountryRepository.php
+++ b/src/Repository/CountryRepository.php
@@ -47,15 +47,15 @@ final class CountryRepository extends ServiceEntityRepository implements DtoFind
         if ($region) {
             $qb
                 ->leftJoin(AdminZone1::class, 'admin_zone1', 'WITH', 'admin_zone1.country = c')
-                ->orWhere('LOWER(admin_zone1.name) LIKE :region')
-                ->setParameter('region', '%' . mb_strtolower($region) . '%');
+                ->orWhere('admin_zone1.name LIKE :region')
+                ->setParameter('region', '%' . $region . '%');
         }
 
         if ($department) {
             $qb
                 ->leftJoin(AdminZone2::class, 'admin_zone2', 'WITH', 'admin_zone2.country = c')
-                ->orWhere('LOWER(admin_zone2.name) LIKE :department')
-                ->setParameter('department', '%' . mb_strtolower($department) . '%');
+                ->orWhere('admin_zone2.name LIKE :department')
+                ->setParameter('department', '%' . $department . '%');
         }
 
         return $qb
@@ -71,8 +71,8 @@ final class CountryRepository extends ServiceEntityRepository implements DtoFind
     {
         return $this
             ->createQueryBuilder('c')
-            ->andWhere('LOWER(c.name) = :country OR LOWER(c.displayName) = :country OR c.id = :country')
-            ->setParameter('country', mb_strtolower((string) $country))
+            ->andWhere('c.name = :country OR c.displayName = :country OR c.id = :country')
+            ->setParameter('country', $country)
             ->getQuery()
             ->enableResultCache()
             ->useQueryCache(true)
@@ -92,7 +92,7 @@ final class CountryRepository extends ServiceEntityRepository implements DtoFind
             if (null !== $dto->code) {
                 $idsWheres[$dto->code] = true;
             } elseif (null !== $dto->name) {
-                $namesWheres[strtolower($dto->name)] = true;
+                $namesWheres[$dto->name] = true;
             }
         }
 
@@ -108,7 +108,7 @@ final class CountryRepository extends ServiceEntityRepository implements DtoFind
         }
 
         if ([] !== $namesWheres) {
-            $wheres[] = 'LOWER(c.name) IN(:names) OR LOWER(c.displayName) IN(:names) OR c.id IN(:names)';
+            $wheres[] = 'c.name IN(:names) OR c.displayName IN(:names) OR c.id IN(:names)';
             $qb->setParameter('names', array_keys($namesWheres));
         }
 

--- a/src/Repository/ZipCityRepository.php
+++ b/src/Repository/ZipCityRepository.php
@@ -66,18 +66,17 @@ final class ZipCityRepository extends ServiceEntityRepository
         if ($city) {
             $cities = [];
             $city = preg_replace("#(^|\s)st\s#i", '$1saint ', $city);
-            $city = str_replace('’', "'", (string) $city);
+            $city = str_replace(''', "'", (string) $city);
             $cities[] = $city;
             $cities[] = str_replace(' ', '-', $city);
             $cities[] = str_replace('-', ' ', $city);
             $cities[] = str_replace("'", '', $city);
-            $cities[] = str_replace('’', "'", $city);
-            $cities[] = str_replace("'", '’', $city);
-            $cities = array_map(mb_strtolower(...), $cities);
+            $cities[] = str_replace(''', "'", $city);
+            $cities[] = str_replace("'", ''', $city);
             $cities = array_unique($cities);
 
             $query
-                ->andWhere('LOWER(zc.name) IN(:cities)')
+                ->andWhere('zc.name IN(:cities)')
                 ->setParameter('cities', $cities);
         }
 

--- a/src/Repository/ZipCityRepository.php
+++ b/src/Repository/ZipCityRepository.php
@@ -73,7 +73,6 @@ final class ZipCityRepository extends ServiceEntityRepository
             $cities[] = str_replace("'", '', $city);
             $cities[] = str_replace('’', "'", $city);
             $cities[] = str_replace("'", '’', $city);
-            $cities = array_map(mb_strtolower(...), $cities);
             $cities = array_unique($cities);
 
             $query

--- a/src/Repository/ZipCityRepository.php
+++ b/src/Repository/ZipCityRepository.php
@@ -66,13 +66,14 @@ final class ZipCityRepository extends ServiceEntityRepository
         if ($city) {
             $cities = [];
             $city = preg_replace("#(^|\s)st\s#i", '$1saint ', $city);
-            $city = str_replace(''', "'", (string) $city);
+            $city = str_replace('’', "'", (string) $city);
             $cities[] = $city;
             $cities[] = str_replace(' ', '-', $city);
             $cities[] = str_replace('-', ' ', $city);
             $cities[] = str_replace("'", '', $city);
-            $cities[] = str_replace(''', "'", $city);
-            $cities[] = str_replace("'", ''', $city);
+            $cities[] = str_replace('’', "'", $city);
+            $cities[] = str_replace("'", '’', $city);
+            $cities = array_map(mb_strtolower(...), $cities);
             $cities = array_unique($cities);
 
             $query


### PR DESCRIPTION
## Summary
- Added PHPDoc generic type annotations to entity provider, factory, and comparator interfaces for better static analysis
- Removed `LOWER()` function calls and `mb_strtolower()` from Doctrine queries since MySQL uses case-insensitive collation
- Fixed error message typo in UserEntityFactory ("city" → "user")
- Minor code cleanup: removed redundant `@inheritDoc` annotations and assertions

## Test plan
- [ ] Verify event imports still match entities correctly with case-insensitive comparisons
- [ ] Run PHPStan to confirm generic types are correctly applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)