### PR TITLE
Use PHP 8.4 LazyObject for lazy-loaded Location entities

### DIFF
--- a/src/App/AppContext.php
+++ b/src/App/AppContext.php
@@ -17,14 +17,13 @@ use Symfony\Contracts\Service\ResetInterface;
 /**
  * Application context service that holds the current location.
  * Acts as a centralized holder for location state that can be accessed globally.
+ *
+ * The Location object may contain lazy-loaded City/Country entities (PHP 8.4 LazyObject)
+ * that are only loaded from the database when their properties are accessed.
  */
 final class AppContext implements ResetInterface
 {
     private ?Location $location = null;
-
-    public function __construct(private readonly CityManager $cityManager)
-    {
-    }
 
     public function reset(): void
     {
@@ -40,20 +39,16 @@ final class AppContext implements ResetInterface
     }
 
     /**
-     * Set the current location and sync with CityManager.
+     * Set the current location.
      */
     public function setLocation(Location $location): void
     {
         $this->location = $location;
-
-        // Sync with CityManager to maintain cookie behavior
-        if ($city = $location->getCity()) {
-            $this->cityManager->setCurrentCity($city);
-        }
     }
 
     /**
      * Get the city from the current location.
+     * Note: This may trigger lazy loading if the city is a ghost object.
      */
     public function getCity(): ?City
     {
@@ -62,6 +57,7 @@ final class AppContext implements ResetInterface
 
     /**
      * Get the country from the current location.
+     * Note: This may trigger lazy loading if the country is a ghost object.
      */
     public function getCountry(): ?Country
     {
@@ -70,6 +66,7 @@ final class AppContext implements ResetInterface
 
     /**
      * Get the slug from the current location.
+     * Note: This may trigger lazy loading.
      */
     public function getSlug(): ?string
     {
@@ -78,6 +75,7 @@ final class AppContext implements ResetInterface
 
     /**
      * Check if the current location is a city.
+     * This does NOT trigger lazy loading as it only checks if the city property is set.
      */
     public function isCity(): bool
     {
@@ -86,6 +84,7 @@ final class AppContext implements ResetInterface
 
     /**
      * Check if the current location is a country.
+     * This does NOT trigger lazy loading as it only checks if the country property is set.
      */
     public function isCountry(): bool
     {

--- a/src/App/LazyLocationFactory.php
+++ b/src/App/LazyLocationFactory.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\App;
+
+use App\Entity\City;
+use App\Entity\Country;
+use App\Repository\CityRepository;
+use App\Repository\CountryRepository;
+use ReflectionClass;
+use RuntimeException;
+
+/**
+ * Factory for creating lazy-loaded Location objects using PHP 8.4 LazyObject.
+ *
+ * This allows creating Location objects with lazy City/Country entities that
+ * are only loaded from the database when their properties are actually accessed,
+ * similar to Doctrine proxy behavior.
+ */
+final readonly class LazyLocationFactory
+{
+    public function __construct(
+        private CityRepository $cityRepository,
+        private CountryRepository $countryRepository,
+    ) {
+    }
+
+    /**
+     * Create a Location with a lazy-loaded City.
+     * The City entity will only be loaded from the database when accessed.
+     */
+    public function createWithLazyCity(string $slug): Location
+    {
+        $reflector = new ReflectionClass(City::class);
+
+        /** @var City $lazyCity */
+        $lazyCity = $reflector->newLazyProxy(function () use ($slug): City {
+            return $this->cityRepository->findOneBySlug($slug)
+                ?? throw new RuntimeException(\sprintf('City with slug "%s" not found', $slug));
+        });
+
+        $location = new Location();
+        $location->setCity($lazyCity);
+
+        return $location;
+    }
+
+    /**
+     * Create a Location with a lazy-loaded Country.
+     * The Country entity will only be loaded from the database when accessed.
+     */
+    public function createWithLazyCountry(string $slug): Location
+    {
+        $reflector = new ReflectionClass(Country::class);
+
+        /** @var Country $lazyCountry */
+        $lazyCountry = $reflector->newLazyProxy(function () use ($slug): Country {
+            return $this->countryRepository->findOneBy(['slug' => $slug])
+                ?? throw new RuntimeException(\sprintf('Country with slug "%s" not found', $slug));
+        });
+
+        $location = new Location();
+        $location->setCountry($lazyCountry);
+
+        return $location;
+    }
+}


### PR DESCRIPTION
Defer database loading of City/Country entities until their properties are actually accessed, similar to Doctrine proxy behavior.

- Add LazyLocationFactory using ReflectionClass::newLazyProxy()
- Update AppContextSubscriber to use lazy loading
- Simplify AppContext by removing CityManager dependency