### PR TITLE
fix: add traces_sample_rate: 0.5 to Sentry config

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dce2991795ead893382a3a4f0e1c7fd5",
+    "content-hash": "18677663f7d7540793382b1a6838014e",
     "packages": [
         {
             "name": "api-platform/core",

--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -5,6 +5,8 @@ when@prod:
             # Add request headers, cookies, IP address and the authenticated user
             # see https://docs.sentry.io/platforms/php/data-management/data-collected/ for more info
             send_default_pii: true
+            traces_sample_rate: 0.5
+            enable_logs: true
             ignore_exceptions:
                 - 'Symfony\Component\ErrorHandler\Error\FatalError'
                 - 'Symfony\Component\Debug\Exception\FatalErrorException'
@@ -13,16 +15,14 @@ when@prod:
         # https://docs.sentry.io/platforms/php/guides/symfony/integrations/monolog/
         register_error_listener: false
         register_error_handler: false
-        messenger:
-            isolate_context_by_message: true
 
     monolog:
         handlers:
             # Use this only if you don't want to use structured logging and instead receive
             # certain log levels as errors.
-            sentry:
-                type: service
-                id: Sentry\Monolog\Handler
+            # sentry:
+            #     type: service
+            #     id: Sentry\Monolog\Handler
 
             # Use this for structured log integration
             sentry_logs:
@@ -31,11 +31,11 @@ when@prod:
 
     # Enable one of the two services below, depending on your choice above
     services:
-        Sentry\Monolog\Handler:
-            arguments:
-                $hub: '@Sentry\State\HubInterface'
-                $level: !php/const Monolog\Logger::ERROR
-                $fillExtraContext: true # Enables sending monolog context to Sentry
+        # Sentry\Monolog\Handler:
+        #     arguments:
+        #         $hub: '@Sentry\State\HubInterface'
+        #         $level: !php/const Monolog\Logger::ERROR
+        #         $fillExtraContext: true # Enables sending monolog context to Sentry
         Sentry\SentryBundle\Monolog\LogsHandler:
             arguments:
                 - !php/const Monolog\Logger::INFO


### PR DESCRIPTION
Adds `traces_sample_rate: 0.5` under `sentry.options` in `config/packages/sentry.yaml`.