### PR TITLE
chore: enable Sentry Monolog handler and raise log level to WARNING

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "737c751c2b63af05df32d3850a0ba8f6",
+    "content-hash": "06047445d1e5da5287185406a4f0a268",
     "packages": [
         {
             "name": "api-platform/core",
@@ -5355,16 +5355,16 @@
         },
         {
             "name": "sentry/sentry",
-            "version": "4.24.0",
+            "version": "4.26.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/getsentry/sentry-php.git",
-                "reference": "5055cc792f630a427fdf9dcccd88faa94b50fd30"
+                "reference": "7597fd10c443929c62489d7cf38d1cb8341d6608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/5055cc792f630a427fdf9dcccd88faa94b50fd30",
-                "reference": "5055cc792f630a427fdf9dcccd88faa94b50fd30",
+                "url": "https://api.github.com/repos/getsentry/sentry-php/zipball/7597fd10c443929c62489d7cf38d1cb8341d6608",
+                "reference": "7597fd10c443929c62489d7cf38d1cb8341d6608",
                 "shasum": ""
             },
             "require": {
@@ -5396,6 +5396,7 @@
                 "spiral/roadrunner-worker": "^3.6"
             },
             "suggest": {
+                "ext-excimer": "Enable Sentry profiling with the Excimer PHP extension.",
                 "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler."
             },
             "type": "library",
@@ -5432,7 +5433,7 @@
             ],
             "support": {
                 "issues": "https://github.com/getsentry/sentry-php/issues",
-                "source": "https://github.com/getsentry/sentry-php/tree/4.24.0"
+                "source": "https://github.com/getsentry/sentry-php/tree/4.26.0"
             },
             "funding": [
                 {
@@ -5444,7 +5445,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2026-04-01T14:34:34+00:00"
+            "time": "2026-04-30T12:50:22+00:00"
         },
         {
             "name": "sentry/sentry-symfony",

--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -18,24 +18,22 @@ when@prod:
 
     monolog:
         handlers:
-            # Use this only if you don't want to use structured logging and instead receive
-            # certain log levels as errors.
-            # sentry:
-            #     type: service
-            #     id: Sentry\Monolog\Handler
+            # Forward ERROR-level Monolog records (incl. uncaught exceptions logged by Symfony) to Sentry as Issues.
+            sentry:
+                type: service
+                id: Sentry\Monolog\Handler
 
-            # Use this for structured log integration
+            # Forward INFO-level+ Monolog records to Sentry as structured Logs.
             sentry_logs:
                 type: service
                 id: Sentry\SentryBundle\Monolog\LogsHandler
 
-    # Enable one of the two services below, depending on your choice above
     services:
-        # Sentry\Monolog\Handler:
-        #     arguments:
-        #         $hub: '@Sentry\State\HubInterface'
-        #         $level: !php/const Monolog\Logger::ERROR
-        #         $fillExtraContext: true # Enables sending monolog context to Sentry
+        Sentry\Monolog\Handler:
+            arguments:
+                $hub: '@Sentry\State\HubInterface'
+                $level: !php/const Monolog\Logger::ERROR
+                $fillExtraContext: true # Enables sending monolog context to Sentry
         Sentry\SentryBundle\Monolog\LogsHandler:
             arguments:
-                - !php/const Monolog\Logger::INFO
+                - !php/const Monolog\Logger::WARNING


### PR DESCRIPTION
## Summary
- Enable the Sentry Monolog handler so ERROR-level Monolog records (including uncaught Symfony exceptions) are forwarded to Sentry as Issues.
- Raise the structured Logs handler threshold from INFO to WARNING.
- Bump `sentry/sentry` via `composer update "sentry/*"`.

## Test plan
- [ ] Trigger an error in prod-like env and verify it appears as an Issue in Sentry.
- [ ] Confirm WARNING+ logs surface in Sentry Logs while INFO logs do not.