### PR TITLE
chore: stop using Sentry Logs (keep Issues via Monolog handler)

### DIFF
--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -6,7 +6,6 @@ when@prod:
             # see https://docs.sentry.io/platforms/php/data-management/data-collected/ for more info
             send_default_pii: true
             traces_sample_rate: 0.5
-            enable_logs: true
             ignore_exceptions:
                 - 'Symfony\Component\ErrorHandler\Error\FatalError'
                 - 'Symfony\Component\Debug\Exception\FatalErrorException'
@@ -23,17 +22,9 @@ when@prod:
                 type: service
                 id: Sentry\Monolog\Handler
 
-            # Forward INFO-level+ Monolog records to Sentry as structured Logs.
-            sentry_logs:
-                type: service
-                id: Sentry\SentryBundle\Monolog\LogsHandler
-
     services:
         Sentry\Monolog\Handler:
             arguments:
                 $hub: '@Sentry\State\HubInterface'
                 $level: !php/const Monolog\Logger::ERROR
                 $fillExtraContext: true # Enables sending monolog context to Sentry
-        Sentry\SentryBundle\Monolog\LogsHandler:
-            arguments:
-                - !php/const Monolog\Logger::WARNING


### PR DESCRIPTION
## Summary
Disable the Sentry Logs feature we wired up earlier:
- Remove `enable_logs: true` from the SDK options.
- Remove the `sentry_logs` Monolog handler.
- Remove the `Sentry\SentryBundle\Monolog\LogsHandler` service.

The `sentry` Monolog handler (ERROR-level Issues with stack traces) stays in place.

## Test plan
- [ ] Trigger an error in prod-like env and verify it still appears as a Sentry Issue.
- [ ] Confirm no log records (INFO/WARNING) are sent to the Sentry Logs ingest endpoint.