### PR TITLE
fix(migration): match legacy utf8 collation for place_name_slug.country_id (MySQL error 3780)

### DIFF
--- a/migrations/Version20260601120000.php
+++ b/migrations/Version20260601120000.php
@@ -22,7 +22,11 @@ final class Version20260601120000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        $this->addSql('CREATE TABLE place_name_slug (id INT AUTO_INCREMENT NOT NULL, place_id INT NOT NULL, city_id INT DEFAULT NULL, country_id VARCHAR(2) DEFAULT NULL, slug VARCHAR(255) NOT NULL, INDEX IDX_ABB0C868DA6A219 (place_id), INDEX IDX_ABB0C8688BAC62AF (city_id), INDEX IDX_ABB0C868F92F3E70 (country_id), INDEX place_name_slug_city_idx (city_id, slug), INDEX place_name_slug_country_idx (country_id, slug), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        // country_id must match the legacy charset/collation of country.id (utf8 / utf8_unicode_ci),
+        // otherwise MySQL rejects the string foreign key (error 3780). city_id (INT) and place_id are
+        // unaffected. The leading DROP makes a previously half-applied run recoverable on re-run.
+        $this->addSql('DROP TABLE IF EXISTS place_name_slug');
+        $this->addSql('CREATE TABLE place_name_slug (id INT AUTO_INCREMENT NOT NULL, place_id INT NOT NULL, city_id INT DEFAULT NULL, country_id VARCHAR(2) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`, slug VARCHAR(255) NOT NULL, INDEX IDX_ABB0C868DA6A219 (place_id), INDEX IDX_ABB0C8688BAC62AF (city_id), INDEX IDX_ABB0C868F92F3E70 (country_id), INDEX place_name_slug_city_idx (city_id, slug), INDEX place_name_slug_country_idx (country_id, slug), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
         $this->addSql('ALTER TABLE place_name_slug ADD CONSTRAINT FK_ABB0C868DA6A219 FOREIGN KEY (place_id) REFERENCES place (id) ON DELETE CASCADE');
         $this->addSql('ALTER TABLE place_name_slug ADD CONSTRAINT FK_ABB0C8688BAC62AF FOREIGN KEY (city_id) REFERENCES admin_zone (id) ON DELETE CASCADE');
         $this->addSql('ALTER TABLE place_name_slug ADD CONSTRAINT FK_ABB0C868F92F3E70 FOREIGN KEY (country_id) REFERENCES country (id) ON DELETE CASCADE');


### PR DESCRIPTION
## Problem
Running the `place_name_slug` migration from #402 fails on the real database:

```
SQLSTATE[HY000]: General error: 3780 Referencing column 'country_id' and referenced
column 'id' in foreign key constraint 'FK_ABB0C868F92F3E70' are incompatible.
```

## Root cause
The migration created `country_id` as `utf8mb4`, but the legacy `country.id` is `VARCHAR(2) CHARACTER SET utf8 COLLATE utf8_unicode_ci` (utf8mb3) — see `Version20170511184229` / `Version20220312205238`. A **string** foreign key requires identical charset **and** collation on both sides, so MySQL rejects it (error 3780).

It slipped through review because it was validated against a fresh `doctrine:schema:create`, where every table (including `country`) is created `utf8mb4` and therefore matched. Only databases with the legacy collation drift hit it.

## Fix
- Pin `country_id` to `CHARACTER SET utf8 COLLATE utf8_unicode_ci` to match `country.id` (same pattern the project already uses for `place.country_id`, `admin_zone.country_id`, etc.).
- Prepend `DROP TABLE IF EXISTS place_name_slug` so the **half-applied** first run self-heals on re-run (MySQL DDL auto-commits, so the failed attempt left the table with the place/city FKs but no country FK; it was never recorded as executed).

## Validation
Reproduced against MySQL 8 with `country.id` as `utf8mb3_unicode_ci`:
1. ❌ `country_id utf8mb4` → **error 3780** (matches the prod failure exactly)
2. ✅ `country_id utf8 / utf8_unicode_ci` → all three FKs create cleanly; `country_id` ends up `utf8mb3_unicode_ci`, `slug` stays `utf8mb4`.

## Deploy / recovery
Just re-run the migration — the leading `DROP TABLE IF EXISTS` clears the partial table from the failed attempt:

```
bin/console doctrine:migrations:migrate
```