### PR TITLE
fix(migration): utf8mb4_unicode_ci for place_name_slug.country_id (matches production country.id)

### DIFF
--- a/migrations/Version20260601120000.php
+++ b/migrations/Version20260601120000.php
@@ -22,11 +22,13 @@ final class Version20260601120000 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // country_id must match the legacy charset/collation of country.id (utf8 / utf8_unicode_ci),
-        // otherwise MySQL rejects the string foreign key (error 3780). city_id (INT) and place_id are
-        // unaffected. The leading DROP makes a previously half-applied run recoverable on re-run.
+        // country_id must match country.id (VARCHAR(2) utf8mb4_unicode_ci) or MySQL rejects the
+        // string foreign key (error 3780). Pinning the table COLLATE to utf8mb4_unicode_ci — the
+        // project's doctrine default_table_options — makes every column inherit it (a bare
+        // "DEFAULT CHARACTER SET utf8mb4" would otherwise pick the server default utf8mb4_0900_ai_ci).
+        // The leading DROP makes a previously half-applied run recoverable on re-run.
         $this->addSql('DROP TABLE IF EXISTS place_name_slug');
-        $this->addSql('CREATE TABLE place_name_slug (id INT AUTO_INCREMENT NOT NULL, place_id INT NOT NULL, city_id INT DEFAULT NULL, country_id VARCHAR(2) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`, slug VARCHAR(255) NOT NULL, INDEX IDX_ABB0C868DA6A219 (place_id), INDEX IDX_ABB0C8688BAC62AF (city_id), INDEX IDX_ABB0C868F92F3E70 (country_id), INDEX place_name_slug_city_idx (city_id, slug), INDEX place_name_slug_country_idx (country_id, slug), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4');
+        $this->addSql('CREATE TABLE place_name_slug (id INT AUTO_INCREMENT NOT NULL, place_id INT NOT NULL, city_id INT DEFAULT NULL, country_id VARCHAR(2) DEFAULT NULL, slug VARCHAR(255) NOT NULL, INDEX IDX_ABB0C868DA6A219 (place_id), INDEX IDX_ABB0C8688BAC62AF (city_id), INDEX IDX_ABB0C868F92F3E70 (country_id), INDEX place_name_slug_city_idx (city_id, slug), INDEX place_name_slug_country_idx (country_id, slug), PRIMARY KEY (id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci`');
         $this->addSql('ALTER TABLE place_name_slug ADD CONSTRAINT FK_ABB0C868DA6A219 FOREIGN KEY (place_id) REFERENCES place (id) ON DELETE CASCADE');
         $this->addSql('ALTER TABLE place_name_slug ADD CONSTRAINT FK_ABB0C8688BAC62AF FOREIGN KEY (city_id) REFERENCES admin_zone (id) ON DELETE CASCADE');
         $this->addSql('ALTER TABLE place_name_slug ADD CONSTRAINT FK_ABB0C868F92F3E70 FOREIGN KEY (country_id) REFERENCES country (id) ON DELETE CASCADE');


### PR DESCRIPTION
## Problem
The `place_name_slug` migration still fails on production with **MySQL error 3780** (incompatible FK columns). The version currently on `main` pins `country_id` to `utf8` (`utf8mb3`), but production `country.id` is:

```
id  varchar(2)  utf8mb4_unicode_ci
```

So both prior states are wrong:
- bare `DEFAULT CHARACTER SET utf8mb4` → `country_id` inherits the MySQL 8 server default **`utf8mb4_0900_ai_ci`** → collation mismatch → 3780
- `CHARACTER SET utf8 COLLATE utf8_unicode_ci` → **`utf8mb3`** → charset mismatch → 3780

## Fix
Pin the table to **`COLLATE utf8mb4_unicode_ci`** (the project's `doctrine.yaml` `default_table_options`). Every column — including `country_id` — inherits it, matching `country.id` exactly.

## Validation (MySQL 8, `country.id` reproduced as `utf8mb4_unicode_ci`)
- `country_id utf8mb4` (no collate → `utf8mb4_0900_ai_ci`) → ❌ **3780**
- `country_id utf8 / utf8_unicode_ci` → ❌ **3780**
- table `COLLATE utf8mb4_unicode_ci` → ✅ all three FKs create cleanly; `country_id` and `slug` end up `utf8mb4_unicode_ci`.

## Recovery / deploy
The migration starts with `DROP TABLE IF EXISTS place_name_slug`, so the half-applied table from the earlier failed run is cleared automatically. Just run:

```
bin/console doctrine:migrations:migrate
```

Supersedes the closed #404.