### PR TITLE
feat(import): merge duplicate Fnac ticket rows into one event with timesheets

### DIFF
--- a/src/Command/EventsMergeDuplicatesCommand.php
+++ b/src/Command/EventsMergeDuplicatesCommand.php
@@ -13,6 +13,7 @@ namespace App\Command;
 use App\Entity\Event;
 use App\Entity\EventTimesheet;
 use App\Repository\EventRepository;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Silarhi\CursorPagination\Configuration\OrderConfiguration;
@@ -25,10 +26,25 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand('app:events:merge-duplicates', 'Find and merge duplicate events based on external_id suffix')]
+#[AsCommand('app:events:merge-duplicates', 'Find and merge duplicate events into a single event with multiple timesheets')]
 final class EventsMergeDuplicatesCommand extends Command
 {
     private const int BATCH_SIZE = 500;
+
+    /**
+     * Group events sharing an external_id base that only differs by a "-N" suffix
+     * (e.g. "SP-123-0", "SP-123-1"). The canonical is the suffix-less base event.
+     */
+    private const string STRATEGY_SUFFIX = 'suffix';
+
+    /**
+     * Group events by content identity (origin + place + name) regardless of their
+     * external_id. Needed for affiliate feeds such as Fnac Spectacles, where every
+     * ticket product of the same show is imported with a distinct external_id.
+     */
+    private const string STRATEGY_CONTENT = 'content';
+
+    private const array STRATEGIES = [self::STRATEGY_SUFFIX, self::STRATEGY_CONTENT];
 
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
@@ -42,6 +58,7 @@ final class EventsMergeDuplicatesCommand extends Command
         $this
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Preview without saving')
             ->addOption('origin', null, InputOption::VALUE_REQUIRED, 'Only process events from this external origin')
+            ->addOption('strategy', null, InputOption::VALUE_REQUIRED, \sprintf('How duplicates are grouped: "%s" or "%s"', self::STRATEGY_SUFFIX, self::STRATEGY_CONTENT), self::STRATEGY_SUFFIX)
             ->addOption('batch-size', null, InputOption::VALUE_REQUIRED, 'Batch size for processing', (string) self::BATCH_SIZE);
     }
 
@@ -50,39 +67,43 @@ final class EventsMergeDuplicatesCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $dryRun = $input->getOption('dry-run');
         $origin = $input->getOption('origin');
+        $strategy = (string) $input->getOption('strategy');
         $batchSize = (int) $input->getOption('batch-size');
 
-        $io->section('Processing duplicate events using cursor pagination...');
+        if (!\in_array($strategy, self::STRATEGIES, true)) {
+            $io->error(\sprintf('Unknown strategy "%s". Expected one of: %s.', $strategy, implode(', ', self::STRATEGIES)));
 
-        $queryBuilder = $this->createDuplicateCandidatesQueryBuilder($origin);
-        $pagination = $this->createPagination($queryBuilder, $batchSize);
+            return Command::INVALID;
+        }
+
+        if (self::STRATEGY_CONTENT === $strategy && null === $origin) {
+            $io->warning('Content strategy groups events by place + name across the whole database. Restrict it with --origin (e.g. --origin=awin.fnac) unless you really mean to merge every origin.');
+        }
+
+        $io->section(\sprintf('Processing duplicate events (strategy: %s) using cursor pagination...', $strategy));
+
+        $queryBuilder = $this->createDuplicateCandidatesQueryBuilder($origin, $strategy);
+        $pagination = $this->createPagination($queryBuilder, $batchSize, $strategy);
 
         $mergedCount = 0;
         $processedGroups = 0;
-        $currentGroup = null;
+        $currentGroup = [];
         $currentGroupKey = null;
-        $canonical = null;
 
         /** @var list<Event> $chunk */
         foreach ($pagination->getChunkResults() as $chunk) {
             foreach ($chunk as $event) {
-                $groupKey = $this->getGroupKey($event);
+                $groupKey = $this->getGroupKey($event, $strategy);
 
                 // New group detected - process the previous group
                 if (null !== $currentGroupKey && $groupKey !== $currentGroupKey) {
-                    $mergedCount += $this->processGroup($currentGroup, $canonical, $dryRun, $io);
+                    $mergedCount += $this->processGroup($currentGroup, $strategy, $currentGroupKey, $dryRun, $io);
                     ++$processedGroups;
                     $currentGroup = [];
-                    $canonical = null;
                 }
 
                 $currentGroupKey = $groupKey;
                 $currentGroup[] = $event;
-
-                // Determine canonical event for this group
-                if (null === $canonical) {
-                    $canonical = $this->findOrSetCanonical($event, $groupKey);
-                }
             }
 
             // Flush and clear after each chunk
@@ -97,8 +118,8 @@ final class EventsMergeDuplicatesCommand extends Command
         }
 
         // Process the last group
-        if (null !== $currentGroupKey && null !== $currentGroup) {
-            $mergedCount += $this->processGroup($currentGroup, $canonical, $dryRun, $io);
+        if (null !== $currentGroupKey && [] !== $currentGroup) {
+            $mergedCount += $this->processGroup($currentGroup, $strategy, $currentGroupKey, $dryRun, $io);
             ++$processedGroups;
 
             if (!$dryRun) {
@@ -117,13 +138,20 @@ final class EventsMergeDuplicatesCommand extends Command
         return Command::SUCCESS;
     }
 
-    private function createDuplicateCandidatesQueryBuilder(?string $origin): QueryBuilder
+    private function createDuplicateCandidatesQueryBuilder(?string $origin, string $strategy): QueryBuilder
     {
         $qb = $this->eventRepository->createQueryBuilder('e')
-            ->where('e.duplicateOf IS NULL')
-            ->andWhere('e.externalId IS NOT NULL')
-            ->andWhere('REGEXP(e.externalId, :pattern) = true')
-            ->setParameter('pattern', '-[0-9]+$');
+            ->where('e.duplicateOf IS NULL');
+
+        if (self::STRATEGY_CONTENT === $strategy) {
+            // Content identity needs a name and a resolved place to group on.
+            $qb->andWhere('e.name IS NOT NULL')
+                ->andWhere('e.placeExternalId IS NOT NULL');
+        } else {
+            $qb->andWhere('e.externalId IS NOT NULL')
+                ->andWhere('REGEXP(e.externalId, :pattern) = true')
+                ->setParameter('pattern', '-[0-9]+$');
+        }
 
         if (null !== $origin) {
             $qb->andWhere('e.externalOrigin = :origin')
@@ -136,22 +164,158 @@ final class EventsMergeDuplicatesCommand extends Command
     /**
      * @return CursorPagination<Event>
      */
-    private function createPagination(QueryBuilder $queryBuilder, int $batchSize): CursorPagination
+    private function createPagination(QueryBuilder $queryBuilder, int $batchSize, string $strategy): CursorPagination
     {
-        $configurations = new OrderConfigurations(
-            new OrderConfiguration('e.externalOrigin', static fn (Event $event): ?string => $event->getExternalOrigin()),
-            new OrderConfiguration('e.externalId', static fn (Event $event): ?string => $event->getExternalId()),
-            new OrderConfiguration('e.id', static fn (Event $event): ?int => $event->getId()),
-        );
+        // The streaming group detection relies on members of a group being
+        // contiguous, so order by exactly the fields that make up the group key.
+        if (self::STRATEGY_CONTENT === $strategy) {
+            $configurations = new OrderConfigurations(
+                new OrderConfiguration('e.externalOrigin', static fn (Event $event): ?string => $event->getExternalOrigin()),
+                new OrderConfiguration('e.placeExternalId', static fn (Event $event): ?string => $event->getPlaceExternalId()),
+                new OrderConfiguration('e.name', static fn (Event $event): ?string => $event->getName()),
+                new OrderConfiguration('e.id', static fn (Event $event): ?int => $event->getId()),
+            );
+        } else {
+            $configurations = new OrderConfigurations(
+                new OrderConfiguration('e.externalOrigin', static fn (Event $event): ?string => $event->getExternalOrigin()),
+                new OrderConfiguration('e.externalId', static fn (Event $event): ?string => $event->getExternalId()),
+                new OrderConfiguration('e.id', static fn (Event $event): ?int => $event->getId()),
+            );
+        }
 
         return new CursorPagination($queryBuilder, $configurations, $batchSize);
     }
 
-    private function getGroupKey(Event $event): string
+    private function getGroupKey(Event $event, string $strategy): string
     {
+        if (self::STRATEGY_CONTENT === $strategy) {
+            return \sprintf('%s|%s|%s', $event->getExternalOrigin(), $event->getPlaceExternalId(), $event->getName());
+        }
+
         $baseId = preg_replace('/-\d+$/', '', $event->getExternalId() ?? '');
 
         return \sprintf('%s|%s', $event->getExternalOrigin(), $baseId);
+    }
+
+    /**
+     * @param list<Event> $events
+     */
+    private function processGroup(array $events, string $strategy, string $groupKey, bool $dryRun, SymfonyStyle $io): int
+    {
+        if ([] === $events) {
+            return 0;
+        }
+
+        $canonical = $this->resolveCanonical($events, $strategy, $groupKey);
+        if (null === $canonical) {
+            return 0;
+        }
+
+        $mergedCount = 0;
+        $canonicalId = $canonical->getId();
+
+        foreach ($events as $event) {
+            if ($event->getId() === $canonicalId) {
+                continue;
+            }
+
+            // Re-fetch canonical if it was cleared from EntityManager
+            $canonical = $this->eventRepository->find($canonicalId);
+            if (null === $canonical) {
+                continue;
+            }
+
+            // Re-fetch duplicate event if cleared
+            $duplicate = $this->eventRepository->find($event->getId());
+            if (null === $duplicate || null !== $duplicate->getDuplicateOf()) {
+                continue;
+            }
+
+            $this->mergeTimesheets($canonical, $duplicate);
+            $duplicate->setDuplicateOf($canonical);
+            ++$mergedCount;
+
+            if ($io->isVerbose()) {
+                $io->writeln(\sprintf(
+                    '  [%s] Event #%d (ext: %s) -> #%d (ext: %s)',
+                    $dryRun ? 'DRY-RUN' : 'MERGE',
+                    $duplicate->getId(),
+                    $duplicate->getExternalId(),
+                    $canonical->getId(),
+                    $canonical->getExternalId()
+                ));
+            }
+        }
+
+        // Keep the canonical's date range in sync with its (now merged) timesheets.
+        if ($mergedCount > 0 && self::STRATEGY_CONTENT === $strategy) {
+            $canonical = $this->eventRepository->find($canonicalId);
+            if (null !== $canonical) {
+                $this->realignDateRange($canonical);
+            }
+        }
+
+        return $mergedCount;
+    }
+
+    /**
+     * @param list<Event> $events
+     */
+    private function resolveCanonical(array $events, string $strategy, string $groupKey): ?Event
+    {
+        if (self::STRATEGY_CONTENT === $strategy) {
+            return $this->selectCanonicalFromGroup($events);
+        }
+
+        return $this->findOrSetCanonical($events[0], $groupKey);
+    }
+
+    /**
+     * Pick the surviving event for a content-grouped show. Prefer the parser's
+     * stable content-hash event (it already carries the real timesheets); fall
+     * back to the oldest event so existing public URLs keep resolving.
+     *
+     * @param list<Event> $events
+     */
+    private function selectCanonicalFromGroup(array $events): ?Event
+    {
+        $canonical = null;
+        foreach ($events as $event) {
+            if (!$this->isContentHashId($event->getExternalId())) {
+                continue;
+            }
+
+            if (null === $canonical || $this->isOlder($event, $canonical)) {
+                $canonical = $event;
+            }
+        }
+
+        if (null !== $canonical) {
+            return $canonical;
+        }
+
+        foreach ($events as $event) {
+            if (null === $canonical || $this->isOlder($event, $canonical)) {
+                $canonical = $event;
+            }
+        }
+
+        return $canonical;
+    }
+
+    private function isOlder(Event $event, Event $reference): bool
+    {
+        return null !== $event->getId()
+            && (null === $reference->getId() || $event->getId() < $reference->getId());
+    }
+
+    /**
+     * A 40-char hex string is the content-hash external_id minted by the parsers
+     * when they collapse duplicate rows, as opposed to a raw merchant product id.
+     */
+    private function isContentHashId(?string $externalId): bool
+    {
+        return null !== $externalId && 1 === preg_match('/^[0-9a-f]{40}$/', $externalId);
     }
 
     private function findOrSetCanonical(Event $event, string $groupKey): Event
@@ -178,82 +342,108 @@ final class EventsMergeDuplicatesCommand extends Command
         return $canonical ?? $event;
     }
 
-    /**
-     * @param list<Event> $events
-     */
-    private function processGroup(array $events, ?Event $canonical, bool $dryRun, SymfonyStyle $io): int
-    {
-        if (null === $canonical || [] === $events) {
-            return 0;
-        }
-
-        $mergedCount = 0;
-        $canonicalId = $canonical->getId();
-
-        foreach ($events as $event) {
-            if ($event->getId() === $canonicalId) {
-                continue;
-            }
-
-            // Re-fetch canonical if it was cleared from EntityManager
-            $canonical = $this->eventRepository->find($canonicalId);
-            if (null === $canonical) {
-                continue;
-            }
-
-            // Re-fetch duplicate event if cleared
-            $duplicate = $this->eventRepository->find($event->getId());
-            if (null === $duplicate) {
-                continue;
-            }
-
-            $this->mergeTimesheets($canonical, $duplicate);
-            $duplicate->setDuplicateOf($canonical);
-            ++$mergedCount;
-
-            if ($io->isVerbose()) {
-                $io->writeln(\sprintf(
-                    '  [%s] Event #%d (ext: %s) -> #%d (ext: %s)',
-                    $dryRun ? 'DRY-RUN' : 'MERGE',
-                    $duplicate->getId(),
-                    $duplicate->getExternalId(),
-                    $canonical->getId(),
-                    $canonical->getExternalId()
-                ));
-            }
-        }
-
-        return $mergedCount;
-    }
-
     private function mergeTimesheets(Event $canonical, Event $duplicate): void
     {
         $canonical->batchUpdate = true;
         $duplicate->batchUpdate = true;
+
         // Get existing timesheet start/end pairs for deduplication
         $existingPairs = [];
         foreach ($canonical->getTimesheets() as $existing) {
-            $key = \sprintf('%s|%s',
-                $existing->getStartAt()?->format('Y-m-d H:i:s') ?? '',
-                $existing->getEndAt()?->format('Y-m-d H:i:s') ?? ''
-            );
-            $existingPairs[$key] = true;
+            $existingPairs[$this->getTimesheetKey($existing->getStartAt(), $existing->getEndAt())] = true;
         }
 
-        foreach ($duplicate->getTimesheets() as $timesheet) {
-            $key = \sprintf('%s|%s',
-                $timesheet->getStartAt()?->format('Y-m-d H:i:s') ?? '',
-                $timesheet->getEndAt()?->format('Y-m-d H:i:s') ?? ''
+        // Legacy canonical events (imported before the timesheet model, e.g. the
+        // one-row-per-ticket Fnac feed) have a start/end date but no timesheet
+        // rows: materialize their own date so it survives the merge.
+        if ([] === $existingPairs && null !== $canonical->getStartDate()) {
+            $this->addTimesheet(
+                $canonical,
+                $canonical->getStartDate(),
+                $canonical->getEndDate() ?? $canonical->getStartDate(),
+                $canonical->getHours(),
+                $existingPairs,
             );
+        }
 
-            if (!isset($existingPairs[$key])) {
-                $newTimesheet = new EventTimesheet();
-                $newTimesheet->setStartAt($timesheet->getStartAt());
-                $newTimesheet->setEndAt($timesheet->getEndAt());
-                $newTimesheet->setHours($timesheet->getHours());
-                $canonical->addTimesheet($newTimesheet);
-                $existingPairs[$key] = true;
+        foreach ($this->getTimesheetTuples($duplicate) as [$startAt, $endAt, $hours]) {
+            $key = $this->getTimesheetKey($startAt, $endAt);
+            if (isset($existingPairs[$key])) {
+                continue;
+            }
+
+            $this->addTimesheet($canonical, $startAt, $endAt, $hours, $existingPairs);
+        }
+    }
+
+    /**
+     * Collect an event's timesheets as [start, end, hours] tuples, synthesizing
+     * one from its start/end date when it has none (legacy, pre-timesheet events).
+     *
+     * @return list<array{0: ?DateTimeImmutable, 1: ?DateTimeImmutable, 2: ?string}>
+     */
+    private function getTimesheetTuples(Event $event): array
+    {
+        $tuples = [];
+        foreach ($event->getTimesheets() as $timesheet) {
+            $tuples[] = [$timesheet->getStartAt(), $timesheet->getEndAt(), $timesheet->getHours()];
+        }
+
+        if ([] === $tuples && null !== $event->getStartDate()) {
+            $tuples[] = [$event->getStartDate(), $event->getEndDate() ?? $event->getStartDate(), $event->getHours()];
+        }
+
+        return $tuples;
+    }
+
+    /**
+     * @param array<string, true> $existingPairs
+     */
+    private function addTimesheet(Event $canonical, ?DateTimeImmutable $startAt, ?DateTimeImmutable $endAt, ?string $hours, array &$existingPairs): void
+    {
+        $timesheet = new EventTimesheet();
+        $timesheet->setStartAt($startAt);
+        $timesheet->setEndAt($endAt);
+        $timesheet->setHours($hours);
+        $canonical->addTimesheet($timesheet);
+
+        $existingPairs[$this->getTimesheetKey($startAt, $endAt)] = true;
+    }
+
+    private function getTimesheetKey(?DateTimeImmutable $startAt, ?DateTimeImmutable $endAt): string
+    {
+        return \sprintf('%s|%s',
+            $startAt?->format('Y-m-d H:i:s') ?? '',
+            $endAt?->format('Y-m-d H:i:s') ?? ''
+        );
+    }
+
+    /**
+     * Widen the canonical's start/end date so it spans every merged timesheet.
+     */
+    private function realignDateRange(Event $canonical): void
+    {
+        $start = null;
+        $end = null;
+        foreach ($canonical->getTimesheets() as $timesheet) {
+            $timesheetStart = $timesheet->getStartAt();
+            $timesheetEnd = $timesheet->getEndAt() ?? $timesheetStart;
+
+            if (null !== $timesheetStart && (null === $start || $timesheetStart < $start)) {
+                $start = $timesheetStart;
+            }
+
+            if (null !== $timesheetEnd && (null === $end || $timesheetEnd > $end)) {
+                $end = $timesheetEnd;
             }
         }
+
+        if (null === $start) {
+            return;
+        }
+
+        $canonical->batchUpdate = true;
+        $canonical->setStartDate($start);
+        $canonical->setEndDate($end ?? $start);
     }
 }

--- a/src/Parser/Common/AbstractAwinParser.php
+++ b/src/Parser/Common/AbstractAwinParser.php
@@ -40,7 +40,7 @@ abstract class AbstractAwinParser extends AbstractParser
      */
     public function parse(bool $incremental): void
     {
-        $path = $this->downloadFile(str_replace('%key%', $this->awinApiKey, $this->getAwinUrl()));
+        $path = $this->downloadFeed();
 
         foreach ($this->parseCsvFile($path) as $data) {
             $event = $this->arrayToDto($data);
@@ -51,9 +51,17 @@ abstract class AbstractAwinParser extends AbstractParser
     }
 
     /**
+     * Download the Awin datafeed (with the API key injected) and return its local path.
+     */
+    protected function downloadFeed(): string
+    {
+        return $this->downloadFile(str_replace('%key%', $this->awinApiKey, $this->getAwinUrl()));
+    }
+
+    /**
      * @return Generator<array<string, string>>
      */
-    private function parseCsvFile(string $path): Generator
+    protected function parseCsvFile(string $path): Generator
     {
         $handle = gzopen($path, 'r');
 

--- a/src/Parser/Common/FnacSpectaclesAwinParser.php
+++ b/src/Parser/Common/FnacSpectaclesAwinParser.php
@@ -13,9 +13,12 @@ namespace App\Parser\Common;
 use App\Dto\CityDto;
 use App\Dto\CountryDto;
 use App\Dto\EventDto;
+use App\Dto\EventTimesheetDto;
 use App\Dto\PlaceDto;
 use App\Handler\EventHandler;
 use DateTimeImmutable;
+use DateTimeInterface;
+use Override;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -66,6 +69,67 @@ final class FnacSpectaclesAwinParser extends AbstractAwinParser
     }
 
     /**
+     * Fnac lists one CSV row per ticket product, so a single show shows up as many
+     * near-identical rows (same name, venue and date, only the merchant_product_id
+     * and affiliate link differ). We collapse those rows on a stable show identity
+     * and publish a single event carrying one timesheet per distinct date.
+     *
+     * {@inheritDoc}
+     */
+    #[Override]
+    public function parse(bool $incremental): void
+    {
+        foreach ($this->groupEvents($this->parseCsvFile($this->downloadFeed())) as $event) {
+            $this->publish($event);
+        }
+    }
+
+    /**
+     * Collapse the raw CSV rows into one event per show, each carrying a timesheet
+     * for every distinct date and a price range spanning all ticket products.
+     *
+     * @param iterable<array<string, string>> $rows
+     *
+     * @return list<EventDto>
+     */
+    protected function groupEvents(iterable $rows): array
+    {
+        /** @var array<string, EventDto> $events */
+        $events = [];
+        /** @var array<string, array{min: float, max: float}> $priceRanges */
+        $priceRanges = [];
+
+        foreach ($rows as $data) {
+            $event = $this->arrayToDto($data);
+            if (null === $event) {
+                continue;
+            }
+
+            // arrayToDto() sets externalId to the show identity shared by every
+            // duplicate row, so it doubles as the grouping key.
+            $key = (string) $event->externalId;
+            $price = (float) ($data['search_price'] ?? 0);
+
+            if (!isset($events[$key])) {
+                $events[$key] = $event;
+                $priceRanges[$key] = ['min' => $price, 'max' => $price];
+
+                continue;
+            }
+
+            $this->mergeDuplicateRow($events[$key], $event);
+            $priceRanges[$key]['min'] = min($priceRanges[$key]['min'], $price);
+            $priceRanges[$key]['max'] = max($priceRanges[$key]['max'], $price);
+        }
+
+        foreach ($events as $key => $event) {
+            $this->finalizeEvent($event, $priceRanges[$key]);
+        }
+
+        return array_values($events);
+    }
+
+    /**
      * {@inheritDoc}
      */
     protected function arrayToDto(array $data): ?EventDto
@@ -81,12 +145,6 @@ final class FnacSpectaclesAwinParser extends AbstractAwinParser
             return null;
         }
 
-        // Parse end date from valid_to (YYYY-mm-dd format)
-        $endDate = DateTimeImmutable::createFromFormat('Y-m-d', $data['valid_to']);
-        if (false === $endDate) {
-            $endDate = $startDate;
-        }
-
         // Parse hours from custom_7 (HH:mm format)
         $hours = null;
         $eventTime = trim($data['custom_7'] ?? '');
@@ -94,16 +152,23 @@ final class FnacSpectaclesAwinParser extends AbstractAwinParser
             $hours = \sprintf('À %s', str_replace(':', 'h', $eventTime));
         }
 
-        // Prevents Reject::BAD_EVENT_DATE_INTERVAL
-        $endDate = $endDate->setTime(0, 0);
+        // Normalize to a date-only value (timesheets are stored as dates).
+        // Also prevents Reject::BAD_EVENT_DATE_INTERVAL.
         $startDate = $startDate->setTime(0, 0);
+
+        // This row is a single performance: model it as one timesheet. Duplicate
+        // rows for the same show are folded together in groupEvents().
+        $timesheet = new EventTimesheetDto();
+        $timesheet->startAt = $startDate;
+        $timesheet->endAt = $startDate;
+        $timesheet->hours = $hours;
 
         $event = new EventDto();
         $event->fromData = self::getParserName();
-        $event->externalId = $data['merchant_product_id'];
         $event->startDate = $startDate;
-        $event->endDate = $endDate;
+        $event->endDate = $startDate;
         $event->hours = $hours;
+        $event->timesheets = [$timesheet];
         $event->source = $data['aw_deep_link'];
         $event->name = $data['product_name'];
         $event->description = nl2br(trim(\sprintf("%s\n\n%s", $data['description'] ?? '', $data['product_short_description'] ?? '')));
@@ -147,7 +212,80 @@ final class FnacSpectaclesAwinParser extends AbstractAwinParser
 
         $event->place = $place;
 
+        // Stable show identity: every ticket product for the same show at the same
+        // place hashes to the same id, so duplicate rows share a grouping key and
+        // re-imports stay idempotent regardless of which products are on sale.
+        $event->externalId = sha1(\sprintf('%s|%s', trim((string) $data['product_name']), $place->externalId));
+
         return $event;
+    }
+
+    /**
+     * Fold a duplicate row (carrying a single timesheet) into the event already
+     * built for this show: add its date if new and widen the event's date range.
+     */
+    private function mergeDuplicateRow(EventDto $event, EventDto $row): void
+    {
+        foreach ($row->timesheets as $timesheet) {
+            if (!$this->hasTimesheetForDate($event, $timesheet->startAt)) {
+                $event->timesheets[] = $timesheet;
+            }
+        }
+
+        if (null !== $row->startDate && (null === $event->startDate || $row->startDate < $event->startDate)) {
+            $event->startDate = $row->startDate;
+        }
+
+        if (null !== $row->endDate && (null === $event->endDate || $row->endDate > $event->endDate)) {
+            $event->endDate = $row->endDate;
+        }
+    }
+
+    private function hasTimesheetForDate(EventDto $event, ?DateTimeInterface $date): bool
+    {
+        if (null === $date) {
+            return false;
+        }
+
+        $needle = $date->format('Y-m-d');
+        foreach ($event->timesheets as $timesheet) {
+            if ($timesheet->startAt?->format('Y-m-d') === $needle) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Once every duplicate row has been folded in, derive the aggregate fields:
+     * chronological timesheets, a shared hours label and the full price range.
+     *
+     * @param array{min: float, max: float} $priceRange
+     */
+    private function finalizeEvent(EventDto $event, array $priceRange): void
+    {
+        usort(
+            $event->timesheets,
+            static fn (EventTimesheetDto $a, EventTimesheetDto $b): int => ($a->startAt?->getTimestamp() ?? 0) <=> ($b->startAt?->getTimestamp() ?? 0),
+        );
+
+        // Surface a single event-level hours label only when every date shares it.
+        $distinctHours = array_values(array_unique(array_filter(array_map(
+            static fn (EventTimesheetDto $timesheet): ?string => $timesheet->hours,
+            $event->timesheets,
+        ))));
+        $event->hours = 1 === \count($distinctHours) ? $distinctHours[0] : null;
+
+        // Reflect the full ticket price range gathered across the duplicate rows.
+        $event->prices = $priceRange['min'] === $priceRange['max']
+            ? \sprintf('%s€', $this->formatPrice($priceRange['min']))
+            : \sprintf('De %s€ à %s€', $this->formatPrice($priceRange['min']), $this->formatPrice($priceRange['max']));
+    }
+
+    private function formatPrice(float $price): string
+    {
+        return rtrim(rtrim(number_format($price, 2, '.', ''), '0'), '.');
     }
 
     private function getImageUrl(string $url): string

--- a/tests/Command/EventsMergeDuplicatesCommandIntegrationTest.php
+++ b/tests/Command/EventsMergeDuplicatesCommandIntegrationTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Tests\Command;
+
+use App\Entity\Event;
+use App\Factory\EventFactory;
+use App\Repository\EventRepository;
+use App\Tests\AppKernelTestCase;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Override;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * End-to-end tests for the content merge strategy (the one that handles affiliate
+ * feeds such as Fnac, where every ticket product lands as a distinct external id).
+ *
+ * The suffix strategy is intentionally not covered here: its candidate query relies
+ * on the MySQL REGEXP function, which the SQLite test database does not provide.
+ */
+final class EventsMergeDuplicatesCommandIntegrationTest extends AppKernelTestCase
+{
+    private const string ORIGIN = 'awin.fnac';
+
+    private EntityManagerInterface $entityManager;
+
+    private EventRepository $eventRepository;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $this->eventRepository = self::getContainer()->get(EventRepository::class);
+    }
+
+    public function testContentStrategyMergesLegacyDuplicatesIntoTheOldestEvent(): void
+    {
+        // Three ticket products of the same show, no timesheets (legacy import shape),
+        // each with its own date. Created in id order, so "2001" is the oldest.
+        $this->fnacEvent('2001', new DateTimeImmutable('2026-07-03'), 'À 13h00');
+        $this->fnacEvent('2002', new DateTimeImmutable('2026-07-01'), 'À 13h00');
+        $this->fnacEvent('2003', new DateTimeImmutable('2026-07-02'), 'À 13h00');
+
+        $this->runMerge(['--strategy' => 'content', '--origin' => self::ORIGIN]);
+
+        $canonical = $this->find('2001');
+        $duplicateA = $this->find('2002');
+        $duplicateB = $this->find('2003');
+
+        // The oldest event survives; the others point at it.
+        self::assertNull($canonical->getDuplicateOf());
+        self::assertSame($canonical->getId(), $duplicateA->getDuplicateOf()?->getId());
+        self::assertSame($canonical->getId(), $duplicateB->getDuplicateOf()?->getId());
+
+        // Every date became a timesheet on the canonical, and its range was realigned.
+        self::assertSame(
+            ['2026-07-01', '2026-07-02', '2026-07-03'],
+            $this->timesheetDates($canonical),
+        );
+        self::assertSame('2026-07-01', $canonical->getStartDate()?->format('Y-m-d'));
+        self::assertSame('2026-07-03', $canonical->getEndDate()?->format('Y-m-d'));
+    }
+
+    public function testContentStrategyKeepsTheContentHashEventAsCanonical(): void
+    {
+        $hashId = sha1('Van Gogh|place-hash');
+
+        // The stable hash event is created *after* a legacy one, so it is not the
+        // oldest, yet it must still win as the canonical.
+        $this->fnacEvent('3001', new DateTimeImmutable('2026-07-05'), 'À 20h00');
+        $this->fnacEvent($hashId, new DateTimeImmutable('2026-07-06'), 'À 20h00');
+        $this->fnacEvent('3002', new DateTimeImmutable('2026-07-07'), 'À 20h00');
+
+        $this->runMerge(['--strategy' => 'content', '--origin' => self::ORIGIN]);
+
+        $canonical = $this->find($hashId);
+        self::assertNull($canonical->getDuplicateOf());
+        self::assertSame($canonical->getId(), $this->find('3001')->getDuplicateOf()?->getId());
+        self::assertSame($canonical->getId(), $this->find('3002')->getDuplicateOf()?->getId());
+    }
+
+    public function testDryRunLeavesEverythingUntouched(): void
+    {
+        $this->fnacEvent('4001', new DateTimeImmutable('2026-07-01'), 'À 18h00');
+        $this->fnacEvent('4002', new DateTimeImmutable('2026-07-02'), 'À 18h00');
+
+        $this->runMerge(['--strategy' => 'content', '--origin' => self::ORIGIN, '--dry-run' => true]);
+
+        self::assertNull($this->find('4001')->getDuplicateOf());
+        self::assertNull($this->find('4002')->getDuplicateOf());
+    }
+
+    /**
+     * Create a Fnac-shaped event sharing one show identity (origin + name + place).
+     */
+    private function fnacEvent(string $externalId, DateTimeImmutable $date, ?string $hours): void
+    {
+        EventFactory::createOne([
+            'externalId' => $externalId,
+            'externalOrigin' => self::ORIGIN,
+            'name' => 'Van Gogh',
+            'placeExternalId' => 'place-hash',
+            'startDate' => $date,
+            'endDate' => $date,
+            'hours' => $hours,
+        ]);
+    }
+
+    /**
+     * @param array<string, bool|string> $input
+     */
+    private function runMerge(array $input): void
+    {
+        $application = new Application(self::$kernel);
+        $tester = new CommandTester($application->find('app:events:merge-duplicates'));
+        $tester->execute($input);
+        $tester->assertCommandIsSuccessful();
+
+        // The command clears the EntityManager; drop any stale identity map so the
+        // assertions below read the persisted state fresh.
+        $this->entityManager->clear();
+    }
+
+    private function find(string $externalId): Event
+    {
+        $event = $this->eventRepository->findOneBy([
+            'externalId' => $externalId,
+            'externalOrigin' => self::ORIGIN,
+        ]);
+
+        self::assertInstanceOf(Event::class, $event);
+
+        return $event;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function timesheetDates(Event $event): array
+    {
+        $dates = array_map(
+            static fn ($timesheet): ?string => $timesheet->getStartAt()?->format('Y-m-d'),
+            $event->getTimesheets()->toArray(),
+        );
+        sort($dates);
+
+        return $dates;
+    }
+}

--- a/tests/Command/EventsMergeDuplicatesCommandIntegrationTest.php
+++ b/tests/Command/EventsMergeDuplicatesCommandIntegrationTest.php
@@ -11,7 +11,13 @@
 namespace App\Tests\Command;
 
 use App\Entity\Event;
+use App\Entity\Place;
+use App\Entity\User;
+use App\Factory\CityFactory;
+use App\Factory\CountryFactory;
 use App\Factory\EventFactory;
+use App\Factory\PlaceFactory;
+use App\Factory\UserFactory;
 use App\Repository\EventRepository;
 use App\Tests\AppKernelTestCase;
 use DateTimeImmutable;
@@ -35,12 +41,28 @@ final class EventsMergeDuplicatesCommandIntegrationTest extends AppKernelTestCas
 
     private EventRepository $eventRepository;
 
+    private Place $place;
+
+    private User $user;
+
     #[Override]
     protected function setUp(): void
     {
         parent::setUp();
         $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
         $this->eventRepository = self::getContainer()->get(EventRepository::class);
+
+        // Duplicates of one show share a single venue. Building it explicitly (rather
+        // than letting EventFactory spawn a random Place per event) keeps the country
+        // code fixed and avoids identity-map collisions on Country's app-assigned PK.
+        $country = CountryFactory::createOne(['id' => 'FR']);
+        $city = CityFactory::createOne(['name' => 'Avignon', 'country' => $country]);
+        $this->place = PlaceFactory::createOne([
+            'name' => 'Théâtre Buffon',
+            'city' => $city,
+            'country' => $country,
+        ]);
+        $this->user = UserFactory::createOne();
     }
 
     public function testContentStrategyMergesLegacyDuplicatesIntoTheOldestEvent(): void
@@ -110,6 +132,8 @@ final class EventsMergeDuplicatesCommandIntegrationTest extends AppKernelTestCas
             'externalOrigin' => self::ORIGIN,
             'name' => 'Van Gogh',
             'placeExternalId' => 'place-hash',
+            'place' => $this->place,
+            'user' => $this->user,
             'startDate' => $date,
             'endDate' => $date,
             'hours' => $hours,

--- a/tests/Command/EventsMergeDuplicatesCommandTest.php
+++ b/tests/Command/EventsMergeDuplicatesCommandTest.php
@@ -1,0 +1,213 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Tests\Command;
+
+use App\Command\EventsMergeDuplicatesCommand;
+use App\Entity\Event;
+use App\Entity\EventTimesheet;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Unit tests for the pure grouping / merging logic of the duplicate merge command.
+ * The DB-backed plumbing (query, pagination, re-fetch) is exercised separately; here
+ * we drive the in-memory decision logic with reflection so no database is required.
+ */
+final class EventsMergeDuplicatesCommandTest extends TestCase
+{
+    private EventsMergeDuplicatesCommand $command;
+
+    protected function setUp(): void
+    {
+        $this->command = (new ReflectionClass(EventsMergeDuplicatesCommand::class))->newInstanceWithoutConstructor();
+    }
+
+    public function testSuffixStrategyGroupsSiblingsBySharedBase(): void
+    {
+        // Suffixed siblings share a base once the trailing "-N" is stripped.
+        $first = $this->event(1, 'SP-99999-0', 'kwanko.seetickets');
+        $second = $this->event(2, 'SP-99999-1', 'kwanko.seetickets');
+        $third = $this->event(3, 'SP-99999-12', 'kwanko.seetickets');
+        $otherShow = $this->event(4, 'SP-88888-0', 'kwanko.seetickets');
+
+        $key = $this->groupKey($first, 'suffix');
+        self::assertSame('kwanko.seetickets|SP-99999', $key);
+        self::assertSame($key, $this->groupKey($second, 'suffix'));
+        self::assertSame($key, $this->groupKey($third, 'suffix'));
+        self::assertNotSame($key, $this->groupKey($otherShow, 'suffix'));
+    }
+
+    public function testContentStrategyGroupsByOriginPlaceAndName(): void
+    {
+        $a = $this->event(1, '21628777', 'awin.fnac', 'Van Gogh', 'place-hash');
+        $b = $this->event(2, '21628778', 'awin.fnac', 'Van Gogh', 'place-hash');
+        $differentPlace = $this->event(3, '21628779', 'awin.fnac', 'Van Gogh', 'other-place');
+
+        $key = $this->groupKey($a, 'content');
+        self::assertSame('awin.fnac|place-hash|Van Gogh', $key);
+        self::assertSame($key, $this->groupKey($b, 'content'));
+        self::assertNotSame($key, $this->groupKey($differentPlace, 'content'));
+    }
+
+    public function testContentHashIdDetection(): void
+    {
+        $method = new ReflectionMethod($this->command, 'isContentHashId');
+
+        self::assertTrue($method->invoke($this->command, sha1('a-show')));
+        self::assertFalse($method->invoke($this->command, '21628777'));
+        self::assertFalse($method->invoke($this->command, 'SP-123-0'));
+        self::assertFalse($method->invoke($this->command, null));
+        self::assertFalse($method->invoke($this->command, strtoupper(sha1('x'))), 'Uppercase hex is not a parser hash.');
+    }
+
+    public function testCanonicalSelectionPrefersTheContentHashEvent(): void
+    {
+        $legacyOld = $this->event(5, '21628777', 'awin.fnac', 'Van Gogh', 'place-hash');
+        $hash = $this->event(20, sha1('Van Gogh|place-hash'), 'awin.fnac', 'Van Gogh', 'place-hash');
+        $legacyNew = $this->event(30, '21628999', 'awin.fnac', 'Van Gogh', 'place-hash');
+
+        $canonical = $this->selectCanonical([$legacyOld, $hash, $legacyNew]);
+
+        self::assertSame($hash, $canonical, 'The stable hash event wins regardless of id ordering.');
+    }
+
+    public function testCanonicalSelectionFallsBackToOldestWhenNoHashEvent(): void
+    {
+        $events = [
+            $this->event(10, '21628777', 'awin.fnac', 'Van Gogh', 'place-hash'),
+            $this->event(4, '21628778', 'awin.fnac', 'Van Gogh', 'place-hash'),
+            $this->event(8, '21628779', 'awin.fnac', 'Van Gogh', 'place-hash'),
+        ];
+
+        $canonical = $this->selectCanonical($events);
+
+        self::assertSame(4, $canonical?->getId(), 'Oldest (lowest id) keeps its public URL.');
+    }
+
+    public function testMergeTimesheetsAddsNewDatesAndDeduplicates(): void
+    {
+        $canonical = $this->event(1, sha1('s'), 'awin.fnac', 'Show', 'p');
+        $canonical->addTimesheet($this->timesheet('2026-08-01', 'À 20h00'));
+
+        $duplicate = $this->event(2, '999', 'awin.fnac', 'Show', 'p');
+        $duplicate->addTimesheet($this->timesheet('2026-08-01', 'À 20h00')); // same date -> deduped
+        $duplicate->addTimesheet($this->timesheet('2026-08-02', 'À 20h00')); // new date -> added
+
+        $this->mergeTimesheets($canonical, $duplicate);
+
+        self::assertSame(['2026-08-01', '2026-08-02'], $this->timesheetDates($canonical));
+        self::assertTrue($canonical->batchUpdate);
+        self::assertTrue($duplicate->batchUpdate);
+    }
+
+    public function testMergeTimesheetsSynthesizesTimesheetFromLegacyDuplicateDate(): void
+    {
+        // Canonical already migrated to the timesheet model.
+        $canonical = $this->event(1, sha1('s'), 'awin.fnac', 'Show', 'p');
+        $canonical->addTimesheet($this->timesheet('2026-08-01', 'À 20h00'));
+
+        // Legacy duplicate: a start date but no timesheet rows.
+        $duplicate = $this->event(2, '999', 'awin.fnac', 'Show', 'p');
+        $duplicate->setStartDate(new DateTimeImmutable('2026-08-05'));
+        $duplicate->setEndDate(new DateTimeImmutable('2026-08-05'));
+        $duplicate->setHours('À 18h00');
+
+        $this->mergeTimesheets($canonical, $duplicate);
+
+        self::assertSame(['2026-08-01', '2026-08-05'], $this->timesheetDates($canonical));
+    }
+
+    public function testMergeTimesheetsSeedsCanonicalOwnDateWhenItHasNone(): void
+    {
+        // Both events predate the timesheet model (legacy-only group).
+        $canonical = $this->event(1, '111', 'awin.fnac', 'Show', 'p');
+        $canonical->setStartDate(new DateTimeImmutable('2026-08-01'));
+        $canonical->setEndDate(new DateTimeImmutable('2026-08-01'));
+        $canonical->setHours('À 13h00');
+
+        $duplicate = $this->event(2, '222', 'awin.fnac', 'Show', 'p');
+        $duplicate->setStartDate(new DateTimeImmutable('2026-08-02'));
+        $duplicate->setEndDate(new DateTimeImmutable('2026-08-02'));
+
+        $this->mergeTimesheets($canonical, $duplicate);
+
+        self::assertSame(['2026-08-01', '2026-08-02'], $this->timesheetDates($canonical));
+    }
+
+    public function testRealignDateRangeSpansEveryTimesheet(): void
+    {
+        $canonical = $this->event(1, sha1('s'), 'awin.fnac', 'Show', 'p');
+        $canonical->addTimesheet($this->timesheet('2026-08-03', null));
+        $canonical->addTimesheet($this->timesheet('2026-08-01', null));
+        $canonical->addTimesheet($this->timesheet('2026-08-05', null));
+
+        (new ReflectionMethod($this->command, 'realignDateRange'))->invoke($this->command, $canonical);
+
+        self::assertSame('2026-08-01', $canonical->getStartDate()?->format('Y-m-d'));
+        self::assertSame('2026-08-05', $canonical->getEndDate()?->format('Y-m-d'));
+    }
+
+    private function groupKey(Event $event, string $strategy): string
+    {
+        return (new ReflectionMethod($this->command, 'getGroupKey'))->invoke($this->command, $event, $strategy);
+    }
+
+    /**
+     * @param list<Event> $events
+     */
+    private function selectCanonical(array $events): ?Event
+    {
+        return (new ReflectionMethod($this->command, 'selectCanonicalFromGroup'))->invoke($this->command, $events);
+    }
+
+    private function mergeTimesheets(Event $canonical, Event $duplicate): void
+    {
+        (new ReflectionMethod($this->command, 'mergeTimesheets'))->invoke($this->command, $canonical, $duplicate);
+    }
+
+    /**
+     * @return list<string|null>
+     */
+    private function timesheetDates(Event $event): array
+    {
+        $dates = array_map(
+            static fn (EventTimesheet $timesheet): ?string => $timesheet->getStartAt()?->format('Y-m-d'),
+            $event->getTimesheets()->toArray(),
+        );
+        sort($dates);
+
+        return $dates;
+    }
+
+    private function event(int $id, string $externalId, string $origin, string $name = 'Show', string $placeExternalId = 'place'): Event
+    {
+        $event = new Event();
+        $event->setId($id);
+        $event->setExternalId($externalId);
+        $event->setExternalOrigin($origin);
+        $event->setName($name);
+        $event->setPlaceExternalId($placeExternalId);
+
+        return $event;
+    }
+
+    private function timesheet(string $date, ?string $hours): EventTimesheet
+    {
+        $timesheet = new EventTimesheet();
+        $timesheet->setStartAt(new DateTimeImmutable($date));
+        $timesheet->setEndAt(new DateTimeImmutable($date));
+        $timesheet->setHours($hours);
+
+        return $timesheet;
+    }
+}

--- a/tests/Parser/Common/FnacSpectaclesAwinParserTest.php
+++ b/tests/Parser/Common/FnacSpectaclesAwinParserTest.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of By Night.
+ * (c) 2013-present Guillaume Sainthillier <guillaume.sainthillier@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace App\Tests\Parser\Common;
+
+use App\Dto\EventDto;
+use App\Parser\Common\FnacSpectaclesAwinParser;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Contracts\Cache\CacheInterface;
+
+/**
+ * The Fnac feed lists one CSV row per ticket product, so a single show appears as
+ * many near-identical rows. {@see FnacSpectaclesAwinParser::groupEvents()} collapses
+ * those into one event carrying a timesheet per distinct date.
+ */
+final class FnacSpectaclesAwinParserTest extends TestCase
+{
+    public function testDuplicateRowsWithSameDateCollapseIntoOneEvent(): void
+    {
+        // 20 ticket products for the same performance (the user-provided example).
+        $rows = [];
+        for ($pid = 21628777; $pid <= 21628796; ++$pid) {
+            $rows[] = $this->row((string) $pid, "Vous n'aimez pas Van Gogh ?", '20.5', '2026-07-25', '13:00');
+        }
+
+        $events = $this->groupEvents($rows);
+
+        self::assertCount(1, $events);
+        $event = $events[0];
+        self::assertSame("Vous n'aimez pas Van Gogh ?", $event->name);
+        self::assertSame('20.5€', $event->prices);
+        self::assertSame('À 13h00', $event->hours);
+        self::assertSame('2026-07-25', $event->startDate?->format('Y-m-d'));
+        self::assertSame('2026-07-25', $event->endDate?->format('Y-m-d'));
+        self::assertCount(1, $event->timesheets);
+        self::assertSame('2026-07-25', $event->timesheets[0]->startAt?->format('Y-m-d'));
+        // External id is the stable content hash, not a raw merchant product id.
+        self::assertMatchesRegularExpression('/^[0-9a-f]{40}$/', (string) $event->externalId);
+    }
+
+    public function testSameShowAcrossSeveralDatesProducesMultipleTimesheets(): void
+    {
+        // Same show, three dates, two price tiers, one duplicated date.
+        $rows = [
+            $this->row('30000001', 'Le Cirque', '15', '2026-08-01', '20:30'),
+            $this->row('30000002', 'Le Cirque', '25', '2026-08-01', '20:30'),
+            $this->row('30000003', 'Le Cirque', '15', '2026-08-02', '20:30'),
+            $this->row('30000004', 'Le Cirque', '15', '2026-08-03', '18:00'),
+        ];
+
+        $events = $this->groupEvents($rows);
+
+        self::assertCount(1, $events);
+        $event = $events[0];
+        self::assertCount(3, $event->timesheets, 'One timesheet per distinct date.');
+        self::assertSame(['2026-08-01', '2026-08-02', '2026-08-03'], array_map(
+            static fn ($timesheet): ?string => $timesheet->startAt?->format('Y-m-d'),
+            $event->timesheets,
+        ));
+        self::assertSame('De 15€ à 25€', $event->prices, 'Price range spans every ticket tier.');
+        self::assertSame('2026-08-01', $event->startDate?->format('Y-m-d'));
+        self::assertSame('2026-08-03', $event->endDate?->format('Y-m-d'));
+        self::assertNull($event->hours, 'No single event-level hours when showtimes differ.');
+    }
+
+    public function testRowsAtDifferentVenuesStaySeparate(): void
+    {
+        $rows = [
+            $this->row('40000001', 'Concert', '30', '2026-09-01', '21:00', 'Zénith', 'Toulouse', '31000', '11 av X'),
+            $this->row('40000002', 'Concert', '30', '2026-09-02', '21:00', 'Olympia', 'Paris', '75009', '28 bd Y'),
+        ];
+
+        $events = $this->groupEvents($rows);
+
+        self::assertCount(2, $events, 'Same name at different places are different shows.');
+    }
+
+    /**
+     * @param list<array<string, string>> $rows
+     *
+     * @return list<EventDto>
+     */
+    private function groupEvents(array $rows): array
+    {
+        $ref = new ReflectionClass(FnacSpectaclesAwinParser::class);
+
+        // Build the parser without its container dependencies and stub the cache so
+        // image-url resolution never touches the network.
+        $parser = $ref->newInstanceWithoutConstructor();
+        $ref->getProperty('cache')->setValue($parser, $this->stubCache());
+
+        /** @var list<EventDto> $events */
+        $events = $ref->getMethod('groupEvents')->invoke($parser, $rows);
+
+        return $events;
+    }
+
+    private function stubCache(): CacheInterface
+    {
+        return new class implements CacheInterface {
+            public function get(string $key, callable $callback, ?float $beta = null, ?array &$metadata = null): mixed
+            {
+                return 'https://image.example/poster.jpg';
+            }
+
+            public function delete(string $key): bool
+            {
+                return true;
+            }
+        };
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function row(
+        string $productId,
+        string $name,
+        string $price,
+        string $eventDate,
+        string $time,
+        string $venue = 'Théâtre Buffon',
+        string $city = 'Avignon',
+        string $postalCode = '84000',
+        string $street = '101 rue de la Carreterie',
+    ): array {
+        return [
+            'aw_deep_link' => \sprintf('https://www.awin1.com/pclick.php?p=%s&a=660995&m=12494', $productId),
+            'product_name' => $name,
+            'merchant_product_id' => $productId,
+            'merchant_image_url' => 'https://www.fnacspectacles.com/obj/poster_547641_4260525_222x222.jpg',
+            'description' => 'Comédie tout public',
+            'search_price' => $price,
+            'is_for_sale' => '1',
+            'valid_to' => '2026-07-25',
+            'product_short_description' => '',
+            'custom_3' => $postalCode,
+            'custom_4' => $street,
+            'custom_5' => 'FR',
+            'custom_7' => $time,
+            'Tickets:venue_name' => $venue,
+            'Tickets:venue_address' => $city,
+            'Tickets:event_date' => $eventDate,
+            'Tickets:latitude' => '43.95',
+            'Tickets:longitude' => '4.82',
+        ];
+    }
+}


### PR DESCRIPTION
## Problem

Fnac Spectacles lists **one CSV row per ticket product**, so a single show is imported as many near-identical events that differ only by `merchant_product_id` (and the affiliate link). Example: *"Vous n'aimez pas Van Gogh ?"* arrives as 20 separate events — same name, venue, date and time.

## Changes

### `FnacSpectaclesAwinParser` — dedupe at parse time
- Mints a **stable content-hash `externalId`** = `sha1(name | place identity)` instead of the per-ticket `merchant_product_id`, and models each row as a single timesheet.
- New `groupEvents()` folds all rows of a show into **one `EventDto`**: one timesheet per distinct date, `startDate`/`endDate` widened to min/max, event-level `hours` only when every date shares it, and `prices` collapsed to a range (`De 15€ à 25€`) across ticket tiers.
- The content hash keeps re-imports **idempotent** regardless of which ticket products are currently on sale.

### `EventsMergeDuplicatesCommand` — backfill existing data
New `--strategy` option:
- **`suffix`** (default): existing `-N` suffix grouping — **unchanged**.
- **`content`**: groups by `origin | placeExternalId | name` for affiliate feeds whose duplicates have distinct external ids. Prefers the content-hash event as canonical (falls back to the oldest for SEO), **synthesizes timesheets** from legacy events that predate the timesheet model, and **realigns** the canonical date range.

Backfill: `bin/console app:events:merge-duplicates --strategy=content --origin=awin.fnac --dry-run`

## Tests
- **Parser** (unit): 20-row example → 1 event/1 timesheet; multi-date show → N timesheets + price range; different venues stay separate.
- **Command merge logic** (unit, reflection — no DB): grouping, hash-id detection, canonical selection, timesheet merge/dedupe/synthesis, date realignment.
- **Command end-to-end** (integration, DB): content strategy merges legacy duplicates into the oldest canonical with synthesized timesheets; the content-hash event wins as canonical; `--dry-run` is a no-op.

> Note: the suffix strategy isn't integration-tested because its candidate query uses the MySQL-only `REGEXP` function and the test DB is SQLite. The content strategy uses portable `IS NOT NULL` predicates and is fully covered end-to-end.

## Verification
- Full suite: **269 tests, 518 assertions — OK**
- PHPStan (level 6): **no errors**
- php-cs-fixer: clean