### PR TITLE
test: assert per-timesheet hours through Fnac grouping and duplicate merge

### DIFF
--- a/tests/Command/EventsMergeDuplicatesCommandIntegrationTest.php
+++ b/tests/Command/EventsMergeDuplicatesCommandIntegrationTest.php
@@ -68,10 +68,10 @@ final class EventsMergeDuplicatesCommandIntegrationTest extends AppKernelTestCas
     public function testContentStrategyMergesLegacyDuplicatesIntoTheOldestEvent(): void
     {
         // Three ticket products of the same show, no timesheets (legacy import shape),
-        // each with its own date. Created in id order, so "2001" is the oldest.
+        // each with its own date and showtime. Created in id order, so "2001" is oldest.
         $this->fnacEvent('2001', new DateTimeImmutable('2026-07-03'), 'À 13h00');
-        $this->fnacEvent('2002', new DateTimeImmutable('2026-07-01'), 'À 13h00');
-        $this->fnacEvent('2003', new DateTimeImmutable('2026-07-02'), 'À 13h00');
+        $this->fnacEvent('2002', new DateTimeImmutable('2026-07-01'), 'À 18h00');
+        $this->fnacEvent('2003', new DateTimeImmutable('2026-07-02'), 'À 20h00');
 
         $this->runMerge(['--strategy' => 'content', '--origin' => self::ORIGIN]);
 
@@ -84,10 +84,15 @@ final class EventsMergeDuplicatesCommandIntegrationTest extends AppKernelTestCas
         self::assertSame($canonical->getId(), $duplicateA->getDuplicateOf()?->getId());
         self::assertSame($canonical->getId(), $duplicateB->getDuplicateOf()?->getId());
 
-        // Every date became a timesheet on the canonical, and its range was realigned.
+        // Every date became a timesheet on the canonical, each keeping its showtime,
+        // and the canonical's range was realigned to span them.
         self::assertSame(
             ['2026-07-01', '2026-07-02', '2026-07-03'],
             $this->timesheetDates($canonical),
+        );
+        self::assertSame(
+            ['2026-07-01' => 'À 18h00', '2026-07-02' => 'À 20h00', '2026-07-03' => 'À 13h00'],
+            $this->timesheetHoursByDate($canonical),
         );
         self::assertSame('2026-07-01', $canonical->getStartDate()?->format('Y-m-d'));
         self::assertSame('2026-07-03', $canonical->getEndDate()?->format('Y-m-d'));
@@ -179,5 +184,20 @@ final class EventsMergeDuplicatesCommandIntegrationTest extends AppKernelTestCas
         sort($dates);
 
         return $dates;
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    private function timesheetHoursByDate(Event $event): array
+    {
+        $hoursByDate = [];
+        foreach ($event->getTimesheets() as $timesheet) {
+            $date = $timesheet->getStartAt()?->format('Y-m-d') ?? '';
+            $hoursByDate[$date] = $timesheet->getHours();
+        }
+        ksort($hoursByDate);
+
+        return $hoursByDate;
     }
 }

--- a/tests/Command/EventsMergeDuplicatesCommandTest.php
+++ b/tests/Command/EventsMergeDuplicatesCommandTest.php
@@ -100,12 +100,17 @@ final class EventsMergeDuplicatesCommandTest extends TestCase
         $canonical->addTimesheet($this->timesheet('2026-08-01', 'À 20h00'));
 
         $duplicate = $this->event(2, '999', 'awin.fnac', 'Show', 'p');
-        $duplicate->addTimesheet($this->timesheet('2026-08-01', 'À 20h00')); // same date -> deduped
-        $duplicate->addTimesheet($this->timesheet('2026-08-02', 'À 20h00')); // new date -> added
+        $duplicate->addTimesheet($this->timesheet('2026-08-01', 'À 23h00')); // same date -> deduped
+        $duplicate->addTimesheet($this->timesheet('2026-08-02', 'À 18h00')); // new date -> added
 
         $this->mergeTimesheets($canonical, $duplicate);
 
         self::assertSame(['2026-08-01', '2026-08-02'], $this->timesheetDates($canonical));
+        // The deduped date keeps the canonical's showtime; the new date carries its own.
+        self::assertSame(
+            ['2026-08-01' => 'À 20h00', '2026-08-02' => 'À 18h00'],
+            $this->timesheetHoursByDate($canonical),
+        );
         self::assertTrue($canonical->batchUpdate);
         self::assertTrue($duplicate->batchUpdate);
     }
@@ -125,6 +130,11 @@ final class EventsMergeDuplicatesCommandTest extends TestCase
         $this->mergeTimesheets($canonical, $duplicate);
 
         self::assertSame(['2026-08-01', '2026-08-05'], $this->timesheetDates($canonical));
+        // The synthesized timesheet inherits the legacy event's hours.
+        self::assertSame(
+            ['2026-08-01' => 'À 20h00', '2026-08-05' => 'À 18h00'],
+            $this->timesheetHoursByDate($canonical),
+        );
     }
 
     public function testMergeTimesheetsSeedsCanonicalOwnDateWhenItHasNone(): void
@@ -138,10 +148,16 @@ final class EventsMergeDuplicatesCommandTest extends TestCase
         $duplicate = $this->event(2, '222', 'awin.fnac', 'Show', 'p');
         $duplicate->setStartDate(new DateTimeImmutable('2026-08-02'));
         $duplicate->setEndDate(new DateTimeImmutable('2026-08-02'));
+        $duplicate->setHours('À 21h00');
 
         $this->mergeTimesheets($canonical, $duplicate);
 
         self::assertSame(['2026-08-01', '2026-08-02'], $this->timesheetDates($canonical));
+        // Both synthesized timesheets carry their source event's hours.
+        self::assertSame(
+            ['2026-08-01' => 'À 13h00', '2026-08-02' => 'À 21h00'],
+            $this->timesheetHoursByDate($canonical),
+        );
     }
 
     public function testRealignDateRangeSpansEveryTimesheet(): void
@@ -187,6 +203,21 @@ final class EventsMergeDuplicatesCommandTest extends TestCase
         sort($dates);
 
         return $dates;
+    }
+
+    /**
+     * @return array<string, string|null>
+     */
+    private function timesheetHoursByDate(Event $event): array
+    {
+        $hoursByDate = [];
+        foreach ($event->getTimesheets() as $timesheet) {
+            $date = $timesheet->getStartAt()?->format('Y-m-d') ?? '';
+            $hoursByDate[$date] = $timesheet->getHours();
+        }
+        ksort($hoursByDate);
+
+        return $hoursByDate;
     }
 
     private function event(int $id, string $externalId, string $origin, string $name = 'Show', string $placeExternalId = 'place'): Event

--- a/tests/Parser/Common/FnacSpectaclesAwinParserTest.php
+++ b/tests/Parser/Common/FnacSpectaclesAwinParserTest.php
@@ -42,6 +42,7 @@ final class FnacSpectaclesAwinParserTest extends TestCase
         self::assertSame('2026-07-25', $event->endDate?->format('Y-m-d'));
         self::assertCount(1, $event->timesheets);
         self::assertSame('2026-07-25', $event->timesheets[0]->startAt?->format('Y-m-d'));
+        self::assertSame('À 13h00', $event->timesheets[0]->hours, 'The timesheet carries the showtime.');
         // External id is the stable content hash, not a raw merchant product id.
         self::assertMatchesRegularExpression('/^[0-9a-f]{40}$/', (string) $event->externalId);
     }
@@ -65,10 +66,31 @@ final class FnacSpectaclesAwinParserTest extends TestCase
             static fn ($timesheet): ?string => $timesheet->startAt?->format('Y-m-d'),
             $event->timesheets,
         ));
+        // Each date keeps its own showtime, even though the event-level label is dropped.
+        self::assertSame(['À 20h30', 'À 20h30', 'À 18h00'], array_map(
+            static fn ($timesheet): ?string => $timesheet->hours,
+            $event->timesheets,
+        ));
         self::assertSame('De 15€ à 25€', $event->prices, 'Price range spans every ticket tier.');
         self::assertSame('2026-08-01', $event->startDate?->format('Y-m-d'));
         self::assertSame('2026-08-03', $event->endDate?->format('Y-m-d'));
         self::assertNull($event->hours, 'No single event-level hours when showtimes differ.');
+    }
+
+    public function testSameDateWithDifferentShowtimesCollapsesToOneTimesheet(): void
+    {
+        // Timesheets are stored per date, so two showtimes on the same day collapse
+        // into a single timesheet that keeps the first-seen showtime label.
+        $rows = [
+            $this->row('50000001', 'Matinée', '12', '2026-09-01', '15:00'),
+            $this->row('50000002', 'Matinée', '12', '2026-09-01', '20:00'),
+        ];
+
+        $events = $this->groupEvents($rows);
+
+        self::assertCount(1, $events);
+        self::assertCount(1, $events[0]->timesheets, 'One timesheet per date, regardless of showtimes.');
+        self::assertSame('À 15h00', $events[0]->timesheets[0]->hours);
     }
 
     public function testRowsAtDifferentVenuesStaySeparate(): void


### PR DESCRIPTION
Follow-up to #407.

That PR was already squash-merged when I noticed a coverage gap: the tests asserted the **event-level** `hours` label but never the **per-timesheet** `hours` (each date's showtime). The behavior was implemented and working — `arrayToDto` sets each timesheet's hours, the merge carries them through, and legacy synthesis pulls `Event::getHours()` — but "working and unasserted" rots silently. This PR adds the assertions.

## Coverage added
- **Parser** (`FnacSpectaclesAwinParserTest`):
  - single timesheet keeps its showtime;
  - distinct dates keep their own labels (`20h30 / 20h30 / 18h00`);
  - new test: two showtimes on one date collapse to one timesheet keeping the first-seen label (documents the per-date storage granularity).
- **Command unit** (`EventsMergeDuplicatesCommandTest`):
  - dedup keeps the **canonical's** hours while a new date carries the **duplicate's**;
  - synthesized timesheets inherit their source event's hours.
- **Command integration** (`EventsMergeDuplicatesCommandIntegrationTest`):
  - distinct per-date showtimes survive the real command merge end-to-end (DB).

## Verification
- Full suite: **270 tests, 527 assertions — OK** (against current `main`, incl. Foundry v2.10.1)
- PHPStan (level 6): no errors
- php-cs-fixer: clean
- Re-checked under `FOUNDRY_FAKER_SEED=723622` (the seed that caught the earlier Country PK collision).