### PR TITLE
test: fix flaky CountryFactory PK collisions (EntityIdentityCollisionException)

### DIFF
--- a/src/Factory/CountryFactory.php
+++ b/src/Factory/CountryFactory.php
@@ -11,6 +11,7 @@
 namespace App\Factory;
 
 use App\Entity\Country;
+use Zenstruck\Foundry\LazyValue;
 use Zenstruck\Foundry\Persistence\PersistentProxyObjectFactory;
 
 /**
@@ -26,7 +27,14 @@ final class CountryFactory extends PersistentProxyObjectFactory
     protected function defaults(): array
     {
         return [
-            'id' => self::faker()->countryCode(),
+            // Country's PK is an app-assigned 2-letter code. faker()->countryCode() is not
+            // unique, so building several countries in one test occasionally minted two with the
+            // same code, tripping Doctrine's EntityIdentityCollisionException — a seed-dependent
+            // (therefore flaky) CI failure. unique() guarantees distinct codes; the closure keeps
+            // it lazy (Foundry replaces overridden LazyValues without resolving them) so callers
+            // pinning an explicit id (e.g. ['id' => 'FR']) bypass it entirely and the bounded
+            // ISO-code pool is only drawn from for "don't care" countries.
+            'id' => LazyValue::new(static fn (): string => self::faker()->unique()->countryCode()),
             'name' => self::faker()->country(),
             'displayName' => self::faker()->country(),
             'atDisplayName' => 'à ' . self::faker()->country(),


### PR DESCRIPTION
## Problem

`EventsMergeDuplicatesCommandIntegrationTest` (and any test that builds several countries) randomly fails in CI with:

```
Doctrine\ORM\Exception\EntityIdentityCollisionException: While adding an entity of
class App\Entity\Country with an ID hash of "MN" to the identity map, another object
of class App\Entity\Country was already present for the same ID.
```

`Country`'s primary key is an **app-assigned** 2-letter code, but [`CountryFactory`](src/Factory/CountryFactory.php) minted it with `faker()->countryCode()` — a **non-unique** draw from only ~250 ISO codes. Whenever one test creates several countries in a single identity map (directly, or transitively via `Place`/`City`/`ZipCity` factories, which all default to `CountryFactory::new()`), two `Country` objects can share a code → Doctrine's identity map rejects the second instance.

Foundry picks a **random faker seed per run**, so the same test passes or fails depending on the seed — hence the intermittent CI failures. (CI hit it at seed `723622`.)

PR #407 patched only the merge test (sharing a pinned `FR` venue). The rest of the suite stays green only because every test *manually* pins `'country' => …` — one forgotten pin re-arms the landmine. This makes the factory itself safe so no test has to remember.

## Fix

```php
'id' => LazyValue::new(static fn (): string => self::faker()->unique()->countryCode()),
```

- `unique()` guarantees distinct codes (matches how `CityFactory` mints its PK).
- `LazyValue` keeps it lazy: an overridden `LazyValue` is *replaced before resolution*, so callers pinning `['id' => 'FR']` bypass it entirely and the bounded ISO pool is only tapped for unpinned "don't care" countries (~30-40/process vs. ~250 available — no overflow risk).

> Note: a **bare** closure does *not* work here — Foundry v2 only treats a value as lazy when it's a `Zenstruck\Foundry\LazyValue`; a plain closure is passed straight to `setId()`.

## Verification

- **Before/after, same CI seed `723622`**: 60 unpinned countries → `EntityIdentityCollisionException` (old) vs. 60 distinct PKs (new).
- **Full suite (269 tests)**: green at a random seed *and* pinned to `723622`.
- `php-cs-fixer` and PHPStan (level 6): clean.