### PR TITLE
Harmonize Sentry config (front and back)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -75,7 +75,7 @@ class App {
                 dsn: parameters.dsn,
                 release: parameters.release,
                 environment: parameters.environment,
-                autoSessionTracking: false,
+                sendDefaultPii: true,
             })
 
             Sentry.getCurrentScope().setUser(this.get('user'))

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,10 @@
     "autoload-dev": {
         "psr-4": {
             "App\\Tests\\": "tests/"
-        }
+        },
+        "exclude-from-classmap": [
+            "/vendor/rector/swiss-knife/stubs/"
+        ]
     },
     "require": {
         "php": "^8.5",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -23,7 +23,7 @@ return [
     EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle::class => ['all' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\MakerBundle\MakerBundle::class => ['dev' => true],
-    Sentry\SentryBundle\SentryBundle::class => ['all' => true],
+    Sentry\SentryBundle\SentryBundle::class => ['prod' => true],
     League\FlysystemBundle\FlysystemBundle::class => ['all' => true],
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
     KnpU\OAuth2ClientBundle\KnpUOAuth2ClientBundle::class => ['all' => true],

--- a/config/packages/sentry.yaml
+++ b/config/packages/sentry.yaml
@@ -6,6 +6,7 @@ when@prod:
             # see https://docs.sentry.io/platforms/php/data-management/data-collected/ for more info
             send_default_pii: true
             #traces_sample_rate: 0.5
+            release: 'v%env(APP_VERSION)%'
             ignore_exceptions:
                 - 'Symfony\Component\ErrorHandler\Error\FatalError'
                 - 'Symfony\Component\Debug\Exception\FatalErrorException'


### PR DESCRIPTION
Frontend: drop the deprecated autoSessionTracking option and enable sendDefaultPii. Backend: add the release option and register the SentryBundle in prod only.