### PR TITLE
ci: make base image tags immutable and releases self-healing

### DIFF
--- a/.github/workflows/build-and-deploy-release.yml
+++ b/.github/workflows/build-and-deploy-release.yml
@@ -6,7 +6,60 @@ on:
             - v*
 
 jobs:
+    # The release build needs guystlr/by-night-base:<docker/base/VERSION>. It is normally
+    # published from main by build-base-image.yml; this job republishes it when missing
+    # (failed run, deleted tag, ...) so releases never depend on that workflow's state.
+    # Published tags are immutable: when the tag exists this is a no-op (~seconds).
+    base:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        outputs:
+            tag: ${{ steps.version.outputs.tag }}
+        steps:
+            - uses: actions/checkout@v7
+
+            - name: Read base image version
+              id: version
+              run: |
+                  TAG=$(cat docker/base/VERSION)
+                  if [ -z "$TAG" ]; then echo "::error::docker/base/VERSION is empty"; exit 1; fi
+                  echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+                  echo "Base image version: $TAG"
+
+            - name: Login to Docker Hub
+              uses: docker/login-action@v4
+              with:
+                  username: ${{ secrets.DOCKER_USERNAME }}
+                  password: ${{ secrets.DOCKER_PASSWORD }}
+
+            - name: Check if base image already exists
+              id: exists
+              run: |
+                  if docker manifest inspect "guystlr/by-night-base:${{ steps.version.outputs.tag }}" > /dev/null 2>&1; then
+                      echo "exists=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "exists=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Set up Docker Buildx
+              if: steps.exists.outputs.exists == 'false'
+              uses: docker/setup-buildx-action@v4
+
+            - name: Build and push base image
+              if: steps.exists.outputs.exists == 'false'
+              uses: docker/build-push-action@v7
+              with:
+                  context: docker/base
+                  push: true
+                  tags: |
+                      guystlr/by-night-base:${{ steps.version.outputs.tag }}
+                      guystlr/by-night-base:php85
+                  cache-from: type=gha,scope=base
+                  cache-to: type=gha,mode=max,scope=base
+
     build:
+        needs: base
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -25,7 +78,6 @@ jobs:
                   MAJOR=$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g" | sed -E "s/v?([0-9]+)\.([0-9]+)\.([0-9]+)(-[a-zA-Z]+(\.[0-9]+)?)?/\1\4/g")
                   echo "version=$VERSION" >> $GITHUB_OUTPUT
                   echo "tags=guystlr/by-night:stable,guystlr/by-night:$VERSION,guystlr/by-night:$MAJOR_MINOR,guystlr/by-night:$MAJOR" >> $GITHUB_OUTPUT
-                  echo "base_tag=$(cat docker/base/VERSION)" >> $GITHUB_OUTPUT
 
             - name: Login to Docker Hub
               uses: docker/login-action@v4
@@ -41,7 +93,7 @@ jobs:
                   tags: ${{ steps.version.outputs.tags }}
                   build-args: |
                       APP_VERSION=${{ steps.version.outputs.version }}
-                      BASE_IMAGE_TAG=${{ steps.version.outputs.base_tag }}
+                      BASE_IMAGE_TAG=${{ needs.base.outputs.tag }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
 

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -5,7 +5,10 @@ name: Build Base Image
 # validate-image-build.yml (which builds base -> app), so there is no PR trigger here.
 #
 # The version is the single source of truth in docker/base/VERSION (e.g. php85-v1).
-# Bump it together with any docker/base/ change.
+# Bump it together with any docker/base/ change. Published tags are immutable: when
+# the tag already exists on Docker Hub this workflow is a no-op, so a docker/base/
+# edit without a VERSION bump is never republished. The release workflow also
+# republishes a missing tag itself, so releases never depend on this workflow's state.
 on:
     workflow_dispatch:
     push:
@@ -23,9 +26,6 @@ jobs:
         steps:
             - uses: actions/checkout@v7
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v4
-
             - name: Read base image version
               id: version
               run: |
@@ -40,7 +40,22 @@ jobs:
                   username: ${{ secrets.DOCKER_USERNAME }}
                   password: ${{ secrets.DOCKER_PASSWORD }}
 
+            - name: Check if base image already exists
+              id: exists
+              run: |
+                  if docker manifest inspect "guystlr/by-night-base:${{ steps.version.outputs.tag }}" > /dev/null 2>&1; then
+                      echo "exists=true" >> "$GITHUB_OUTPUT"
+                      echo "::notice::guystlr/by-night-base:${{ steps.version.outputs.tag }} is already published — skipping (tags are immutable, bump docker/base/VERSION to publish changes)"
+                  else
+                      echo "exists=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Set up Docker Buildx
+              if: steps.exists.outputs.exists == 'false'
+              uses: docker/setup-buildx-action@v4
+
             - name: Build and push
+              if: steps.exists.outputs.exists == 'false'
               uses: docker/build-push-action@v7
               with:
                   context: docker/base

--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ immutable version tags (`php85-v1`, `php85-v2`, …). The single source of truth
 **`docker/base/VERSION`**, and the app's `ARG BASE_IMAGE_TAG` has **no default** — it
 must be passed explicitly on every build.
 
-`.github/workflows/build-base-image.yml` builds the base on PRs that touch
-`docker/base/` (validation only) and publishes it on `main` / manual dispatch; the
-release workflow passes `BASE_IMAGE_TAG` from `docker/base/VERSION` automatically.
+`.github/workflows/build-base-image.yml` publishes the base on `main` / manual
+dispatch — since published tags are immutable, it is a no-op when the
+`docker/base/VERSION` tag already exists. The release workflow passes
+`BASE_IMAGE_TAG` from `docker/base/VERSION` automatically and republishes a missing
+base tag itself before building the app, so releases are self-healing. PR validation
+is handled by `validate-image-build.yml` (builds base then app, no push).
 
 For local builds, export the version first, then build/pull:
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -7,9 +7,14 @@
 # slowest part of a cold build, and it changes rarely — only when PHP, the extension list,
 # or the mjml version changes.
 #
-# Build & publish (see .github/workflows/build-base-image.yml):
-#   docker build -t guystlr/by-night-base:php8.5 docker/base
-#   docker push  guystlr/by-night-base:php8.5
+# The version is the single source of truth in docker/base/VERSION (e.g. php85-v1);
+# bump it together with any docker/base/ change. Published tags are immutable — the
+# publishing workflows (build-base-image.yml, and the base job of
+# build-and-deploy-release.yml as a fallback) skip tags that already exist.
+#
+# Build & publish manually:
+#   docker build -t guystlr/by-night-base:$(cat docker/base/VERSION) docker/base
+#   docker push  guystlr/by-night-base:$(cat docker/base/VERSION)
 
 # ── PHP extensions (installed once, shared by the builder and the runtime base) ──
 FROM dunglas/frankenphp:1.12-php8.5-alpine AS php_ext


### PR DESCRIPTION
## What

Aligns the base-image machinery with the pattern just rolled out to avis-banque.fr, offre-parrainages.fr, parrainages-boursorama.fr and time-tracking.silarhi.dev (which was itself derived from this repo):

- **`build-base-image.yml`** now checks Docker Hub (`docker manifest inspect`) and skips the build when `guystlr/by-night-base:<docker/base/VERSION>` is already published. Tags become truly immutable: a `docker/base/` edit without a `VERSION` bump is never republished (previously the tag was silently overwritten).
- **`build-and-deploy-release.yml`** gains a `base` job ahead of the app build that republishes a missing base tag (failed run, deleted tag, brand-new VERSION tagged before the main workflow finished). Releases no longer depend on `build-base-image.yml` having run — a no-op (~seconds) when the tag exists.
- `docker/base/Dockerfile` header (stale `php8.5` tag example) and the README Docker section updated to match.

## Why

The README already documented the tags as immutable, but nothing enforced it. The existence check makes it real, and the self-healing `base` job removes the one ordering assumption between the two workflows.

## Notes

- No behavior change for normal flows: base publishes from main on `docker/base/` changes as before (now idempotently), releases build exactly as before when the base exists.
- `validate-image-build.yml` (PR-time base → app compile check) is untouched and will validate this PR since it touches `docker/base/`.
